### PR TITLE
Pass template dir as parameter using `--db`

### DIFF
--- a/kpet/exceptions.py
+++ b/kpet/exceptions.py
@@ -16,3 +16,7 @@
 
 class ActionNotFound(Exception):
     """Raised when an action is not found"""
+
+
+class ParameterNotFound(Exception):
+    """Raised when there is a missing parameter"""

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -21,7 +21,7 @@ from kpet import utils
 def generate(args):
     """Generate an xml output compatible with beaker"""
     tree = '{}.xml'.format(args.tree)
-    template_content = utils.get_template_content(tree)
+    template_content = utils.get_template_content(tree, args.db)
     content = template_content.format(
         DESCRIPTION=escape(args.description),
         ARCH=quoteattr(args.arch),

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -14,12 +14,14 @@
 """Module where the `run` command is implemented"""
 from __future__ import print_function
 from xml.sax.saxutils import escape, quoteattr
-from kpet.exceptions import ActionNotFound
+from kpet.exceptions import ActionNotFound, ParameterNotFound
 from kpet import utils
 
 
 def generate(args):
     """Generate an xml output compatible with beaker"""
+    if not args.db:
+        raise ParameterNotFound('--db is required')
     tree = '{}.xml'.format(args.tree)
     template_content = utils.get_template_content(tree, args.db)
     content = template_content.format(

--- a/kpet/utils.py
+++ b/kpet/utils.py
@@ -19,17 +19,17 @@ class TemplateNotFound(Exception):
     """Raised when an template is not found"""
 
 
-def get_template_path(filename):
+def get_template_path(filename, dbdir=None):
     """Return the full path for the corresponding template"""
-    current_dir = os.path.realpath(os.path.dirname(__file__))
-    path = os.path.join(current_dir, 'templates', filename)
+    workdir = dbdir or os.path.realpath(os.path.dirname(__file__))
+    path = os.path.join(workdir, 'templates', filename)
     if not os.path.exists(path):
         raise TemplateNotFound(path)
     return path
 
 
-def get_template_content(filename):
+def get_template_content(filename, dbdir=None):
     """Return the content for the corresponding template"""
-    template_path = get_template_path(filename)
+    template_path = get_template_path(filename, dbdir)
     with open(template_path) as file_handler:
         return file_handler.read()

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -16,7 +16,7 @@ import os
 import tempfile
 import unittest
 import mock
-from kpet import run, utils
+from kpet import run, utils, exceptions
 
 
 class RunTest(unittest.TestCase):
@@ -34,6 +34,9 @@ class RunTest(unittest.TestCase):
         mock_args.arch = 'baz'
         mock_args.output = ''
         mock_args.db = ''
+        self.assertRaises(exceptions.ParameterNotFound, run.generate,
+                          mock_args)
+        mock_args.db = 'kpet'
         template_content = utils.get_template_content(mock_args.tree + '.xml')
         content_expected = template_content.format(
             DESCRIPTION=mock_args.description,

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -33,6 +33,7 @@ class RunTest(unittest.TestCase):
         mock_args.kernel = 'bar'
         mock_args.arch = 'baz'
         mock_args.output = ''
+        mock_args.db = ''
         template_content = utils.get_template_content(mock_args.tree + '.xml')
         content_expected = template_content.format(
             DESCRIPTION=mock_args.description,


### PR DESCRIPTION
Use `--db` parameter to provide an alternative path for templates

Despite it's counter intuitive, `--db` parameter will be used in the future to get the metadata of the tests like testsuite will run, waived tests, etc and also the templates.
