### PR TITLE
Split ARCH in two variables -> ARCH_ATTR=quoted ARCH_RAW=unquoted

### DIFF
--- a/kpet/run.py
+++ b/kpet/run.py
@@ -26,7 +26,8 @@ def generate(args):
     template_content = utils.get_template_content(tree, args.db)
     content = template_content.format(
         DESCRIPTION=escape(args.description),
-        ARCH=quoteattr(args.arch),
+        ARCH_RAW=escape(args.arch),
+        ARCH_ATTR=quoteattr(args.arch),
         KURL=quoteattr(args.kernel),
     )
     if not args.output:

--- a/kpet/templates/ark.xml
+++ b/kpet/templates/ark.xml
@@ -6,12 +6,12 @@
         <and>
           <name op="=" value="RHEL-8.0"/>
           <variant op="=" value="BaseOS"/>
-          <distro_arch op="=" value={ARCH}/>
+          <distro_arch op="=" value={ARCH_ATTR}/>
         </and>
       </distroRequires>
       <hostRequires>
         <and>
-          <arch op="=" value={ARCH}/>
+          <arch op="=" value={ARCH_ATTR}/>
           <not><hostname op="like" value="%gigabyte%"/></not>
         </and>
         <or>
@@ -28,7 +28,7 @@
 cat >/etc/yum.repos.d/BUILDROOT-8.repo <<EOF
 [BUILDROOT-8]
 name=BUILDROOT-8
-baseurl=http://example.com/compose/Buildroot/{ARCH}/os/
+baseurl=http://example.com/compose/Buildroot/{ARCH_RAW}/os/
 enabled=1
 gpgcheck=0
 EOF

--- a/kpet/templates/rhel7.xml
+++ b/kpet/templates/rhel7.xml
@@ -7,12 +7,12 @@
           <distro_family op="=" value="RedHatEnterpriseLinux7"/>
           <distro_name op="=" value="RHEL-7.5"/>
           <distro_variant op="=" value="Server"/>
-          <distro_arch op="=" value={ARCH}/>
+          <distro_arch op="=" value={ARCH_ATTR}/>
         </and>
       </distroRequires>
       <hostRequires>
         <and>
-          <arch op="=" value={ARCH}/>
+          <arch op="=" value={ARCH_ATTR}/>
         </and>
         <or>
           <labcontroller op="=" value="lab01.example.com"/>

--- a/kpet/templates/rhel8.xml
+++ b/kpet/templates/rhel8.xml
@@ -6,12 +6,12 @@
         <and>
           <name op="=" value="RHEL-8.0"/>
           <variant op="=" value="BaseOS"/>
-          <distro_arch op="=" value={ARCH}/>
+          <distro_arch op="=" value={ARCH_ATTR}/>
         </and>
       </distroRequires>
       <hostRequires>
         <and>
-          <arch op="=" value={ARCH}/>
+          <arch op="=" value={ARCH_ATTR}/>
           <not><hostname op="like" value="%gigabyte%"/></not>
         </and>
         <or>
@@ -28,7 +28,7 @@
 cat >/etc/yum.repos.d/BUILDROOT-8.repo <<EOF
 [BUILDROOT-8]
 name=BUILDROOT-8
-baseurl=http://example.com/compose/Buildroot/{ARCH}/os/
+baseurl=http://example.com/compose/Buildroot/{ARCH_RAW}/os/
 enabled=1
 gpgcheck=0
 EOF

--- a/kpet/templates/upstream.xml
+++ b/kpet/templates/upstream.xml
@@ -7,12 +7,12 @@
           <distro_family op="=" value="RedHatEnterpriseLinux7"/>
           <distro_name op="=" value="RHEL-7.5"/>
           <distro_variant op="=" value="Server"/>
-          <distro_arch op="=" value={ARCH}/>
+          <distro_arch op="=" value={ARCH_ATTR}/>
         </and>
       </distroRequires>
       <hostRequires>
         <and>
-          <arch op="=" value={ARCH}/>
+          <arch op="=" value={ARCH_ATTR}/>
         </and>
         <or>
           <labcontroller op="=" value="lab01.example.com"/>

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -40,7 +40,8 @@ class RunTest(unittest.TestCase):
         template_content = utils.get_template_content(mock_args.tree + '.xml')
         content_expected = template_content.format(
             DESCRIPTION=mock_args.description,
-            ARCH='"{}"'.format(mock_args.arch),
+            ARCH_RAW='{}'.format(mock_args.arch),
+            ARCH_ATTR='"{}"'.format(mock_args.arch),
             KURL='"{}"'.format(mock_args.kernel),
         )
         with mock.patch('sys.stdout') as mock_stdout:


### PR DESCRIPTION
The ARCH_RAW is just escaped while the other ARCH_ATTR is sanitized as an xml attribute i.e. quoted most of the times. It closes: #5