### PR TITLE
`--db` parameter global, required and `help` command removed

### DIFF
--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -157,6 +157,7 @@ def main():
     parser.add_argument(
         '--db',
         help='Location of database of kernel trees and tests',
+        required=True,
     )
     cmds_parser = parser.add_subparsers(title="Command", dest="command")
 

--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -160,10 +160,6 @@ def main():
     )
     cmds_parser = parser.add_subparsers(title="Command", dest="command")
 
-    cmds_parser.add_parser(
-        'help',
-        help='show this help message and exit',
-    )
     build_run_command(cmds_parser, common_parser)
     build_tree_command(cmds_parser, common_parser)
     build_arch_command(cmds_parser, common_parser)

--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -146,7 +146,7 @@ def exec_command(args, commands):
         raise
 
 
-def main():
+def main(args=None):
     """Entry point for kpet tool"""
     logging.basicConfig(format="%(created)10.6f:%(levelname)s:%(message)s")
     logging.getLogger().setLevel(os.environ.get('LOG_LEVEL', 'INFO'))
@@ -165,7 +165,7 @@ def main():
     build_tree_command(cmds_parser, common_parser)
     build_arch_command(cmds_parser, common_parser)
 
-    args = parser.parse_args()
+    args = parser.parse_args(args)
     commands = {
         'help': [parser.print_help],
         'run': [run.main, args],

--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -153,11 +153,11 @@ def main():
     description = "KPET - Kernel Patch-Evaluated Testing"
     common_parser = argparse.ArgumentParser(add_help=False)
     common_parser.add_argument('--verbose', '-v', action='count')
-    common_parser.add_argument(
+    parser = argparse.ArgumentParser(description=description)
+    parser.add_argument(
         '--db',
         help='Location of database of kernel trees and tests',
     )
-    parser = argparse.ArgumentParser(description=description)
     cmds_parser = parser.add_subparsers(title="Command", dest="command")
 
     cmds_parser.add_parser(

--- a/kpet/exceptions.py
+++ b/kpet/exceptions.py
@@ -16,7 +16,3 @@
 
 class ActionNotFound(Exception):
     """Raised when an action is not found"""
-
-
-class ParameterNotFound(Exception):
-    """Raised when there is a missing parameter"""

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -14,14 +14,12 @@
 """Module where the `run` command is implemented"""
 from __future__ import print_function
 from xml.sax.saxutils import escape, quoteattr
-from kpet.exceptions import ActionNotFound, ParameterNotFound
+from kpet.exceptions import ActionNotFound
 from kpet import utils
 
 
 def generate(args):
     """Generate an xml output compatible with beaker"""
-    if not args.db:
-        raise ParameterNotFound('--db is required')
     template_content = utils.get_template_content(args.tree, args.db)
     content = template_content.format(
         DESCRIPTION=escape(args.description),

--- a/tests/test_kpet.py
+++ b/tests/test_kpet.py
@@ -12,6 +12,7 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Test cases for main module"""
+import os
 import unittest
 import argparse
 import mock
@@ -98,3 +99,18 @@ class ArgumentParserTest(unittest.TestCase):
                 mock_stdout.write.call_args_list[0],
                 mock.call('Not implemented yet'),
             )
+
+    def test_main(self):
+        """
+        Check --db is required and also run generate command executes
+        successfully
+        """
+        dbdir = os.path.join(os.path.dirname(__file__), 'assets')
+        args = ['run', 'generate', '-t', 'rhel7', '-k',
+                'url']
+        self.assertRaises(SystemExit, kpet.main, args)
+        args = ['--db', dbdir, 'run', 'generate', '-t', 'rhel7', '-k',
+                'url']
+        with mock.patch('sys.stdout') as mock_stdout:
+            kpet.main(args)
+        self.assertIn('whiteboard', mock_stdout.write.call_args_list[0][0][0])

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -16,7 +16,7 @@ import os
 import tempfile
 import unittest
 import mock
-from kpet import run, utils, exceptions
+from kpet import run, utils
 
 
 class RunTest(unittest.TestCase):
@@ -33,9 +33,6 @@ class RunTest(unittest.TestCase):
         mock_args.kernel = 'bar'
         mock_args.arch = 'baz'
         mock_args.output = ''
-        mock_args.db = ''
-        self.assertRaises(exceptions.ParameterNotFound, run.generate,
-                          mock_args)
         dbdir = os.path.join(os.path.dirname(__file__), 'assets')
         mock_args.db = 'kpet'
         mock_args.db = dbdir


### PR DESCRIPTION
Otherwise to use the `help` command you should pass `--db` as parameter which is really counter intuitive. I think it's a good trade off lack of `help` command but have `--db` parameter as required.