### PR TITLE
FASTMOVING-227 : KPET should generate patch related test cases

### DIFF
--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -93,6 +93,18 @@ def build_run_command(cmds_parser, common_parser):
         help='Patch series cover letter mbox URL/path'
     )
     action_parser.add_argument(
+        '-l',
+        '--layout',
+        help='Layout of smart testing'
+    )
+    action_parser.add_argument(
+        '-otc',
+        '--output-testcase',
+        action='store_true',
+        default=False,
+        help='Output test cases according to patch series'
+    )
+    action_parser.add_argument(
         'mboxes',
         nargs='*',
         default=[],

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -13,13 +13,47 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Module where the `run` command is implemented"""
 from __future__ import print_function
+import logging
 from xml.sax.saxutils import escape, quoteattr
 from kpet.exceptions import ActionNotFound
 from kpet import utils
 
 
+def get_test_cases(l_patch, f_layout):
+    """Get test cases by querying layout according list of patch files"""
+    l_srcfiles = utils.smart_get_src_files(l_patch)
+    if not l_srcfiles:
+        logging.info("No source file updated")
+        return []
+
+    l_cases = utils.smart_get_test_cases(l_srcfiles, f_layout)
+    if l_cases is None:
+        logging.error("Fail to get test cases")
+        return None
+
+    return l_cases
+
+
 def generate(args):
-    """Generate an xml output compatible with beaker"""
+    """Generate an xml output compatible with beaker OR output test cases"""
+    # Output test cases only
+    if args.output_testcase:
+        if not args.mboxes:
+            logging.error("No patch file specified")
+            return 1
+
+        if not args.layout:
+            logging.error("No layout file specified")
+            return 1
+
+        l_tc = get_test_cases(args.mboxes, args.layout)
+        if l_tc is None:
+            logging.error("No test case found")
+            return 1
+
+        print(','.join(l_tc))
+        return 0
+
     template_content = utils.get_template_content(args.tree, args.db)
     content = template_content.format(
         DESCRIPTION=escape(args.description),
@@ -32,6 +66,8 @@ def generate(args):
     else:
         with open(args.output, 'w') as file_handler:
             file_handler.write(content)
+
+    return 0
 
 
 def main(args):

--- a/kpet/utils.py
+++ b/kpet/utils.py
@@ -13,6 +13,10 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Utils used across kpet's commands"""
 import os
+import json
+import collections
+import re
+import logging
 
 
 class TemplateNotFound(Exception):
@@ -33,3 +37,88 @@ def get_template_content(tree, dbdir):
     template_path = get_template_path(tree, dbdir)
     with open(template_path) as file_handler:
         return file_handler.read()
+
+
+def smart_get_patterns_bylayout(d_layout, f_layout):
+    """Return patterns of layout"""
+    layout_prefix = os.path.dirname(os.path.realpath(f_layout))
+
+    l_patterns = []
+    for key in d_layout:
+        val = d_layout[key]
+        if val is None:
+            continue
+
+        s_file = os.path.join(layout_prefix, val)
+        d_pattern = None
+        with open(s_file, 'r') as file_handler:
+            d_pattern = json.load(file_handler,
+                                  object_pairs_hook=collections.OrderedDict)
+        for pattern in d_pattern['patterns']:
+            if pattern not in l_patterns:
+                l_patterns.append(pattern)
+
+    return l_patterns
+
+
+def smart_get_src_files(l_patch):
+    """Get source files according to list of patch files"""
+    # USE `unidiff` instead (fixme)
+
+    pattern = re.compile(r'^diff --git a/.* b/.*')
+
+    l_src = []
+    for f_patch in l_patch:
+        with open(f_patch, 'r') as file_handler:
+            while True:
+                line = file_handler.readline()
+                if not line:
+                    break
+
+                if pattern.match(line.strip()) is None:
+                    continue
+
+                line = line.rstrip()
+                l_line = line.split(' ')
+                srcfile = l_line[-1].replace('b/', '')
+                if srcfile not in l_src:
+                    l_src.append(srcfile)
+
+    return l_src
+
+
+def smart_get_test_cases(l_src, f_layout):
+    """Get test cases by querying layout according to source files"""
+    # get layout
+    d_layout = None
+    with open(f_layout, 'r') as file_handler:
+        d_layout = json.load(file_handler,
+                             object_pairs_hook=collections.OrderedDict)
+        if d_layout is None:
+            logging.error("Fail to get layout")
+            return None
+
+    # get patterns by layout
+    l_patterns = smart_get_patterns_bylayout(d_layout, f_layout)
+    if l_patterns is None:
+        logging.error("Fail to get patterns")
+        return None
+
+    # get cases by patterns
+    l_cases = []
+    for element in l_patterns:
+        pattern = element['pattern']
+        case = element['case']
+
+        pattern = re.compile(r'%s' % pattern)
+        for f_src in l_src:
+            ret = pattern.match(f_src)
+            if ret is None:
+                continue
+
+            if case in l_cases:
+                continue
+            else:
+                l_cases.append(case)
+
+    return l_cases


### PR DESCRIPTION
According to Agustin's suggestion, the first PR is just to output the test cases according to patch files.

Here is a sample usage:
$ export LAYOUT=/tmp/kpet-db/layout/layout.json
$ bin/kpet run generate -t ark -k /tmp/foo.tar.gz -l $LAYOUT --output-testcase /tmp/foo.patch /tmp/bar.patch
default/ltplite,fs/ext4,fs/xfs
