### PR TITLE
targeted: Support more patch formats

### DIFF
--- a/tests/assets/patches/20-23-zfcp-silence-remaining-kdoc-warnings-in-header-files.diff
+++ b/tests/assets/patches/20-23-zfcp-silence-remaining-kdoc-warnings-in-header-files.diff
@@ -1,0 +1,157 @@
+diff --git a/drivers/s390/scsi/zfcp_dbf.h b/drivers/s390/scsi/zfcp_dbf.h
+index b4438713d1cc..900c779cc39b 100644
+--- a/drivers/s390/scsi/zfcp_dbf.h
++++ b/drivers/s390/scsi/zfcp_dbf.h
+@@ -42,7 +42,8 @@ struct zfcp_dbf_rec_trigger {
+  * @fsf_req_id: request id for fsf requests
+  * @rec_status: status of the fsf request
+  * @rec_step: current step of the recovery action
+- * rec_count: recovery counter
++ * @rec_action: ERP action type
++ * @rec_count: recoveries including retries for particular @rec_action
+  */
+ struct zfcp_dbf_rec_running {
+ 	u64 fsf_req_id;
+@@ -72,6 +73,7 @@ enum zfcp_dbf_rec_id {
+  * @adapter_status: current status of the adapter
+  * @port_status: current status of the port
+  * @lun_status: current status of the lun
++ * @u: record type specific data
+  * @u.trig: structure zfcp_dbf_rec_trigger
+  * @u.run: structure zfcp_dbf_rec_running
+  */
+@@ -126,6 +128,8 @@ struct zfcp_dbf_san {
+  * @prot_status_qual: protocol status qualifier
+  * @fsf_status: fsf status
+  * @fsf_status_qual: fsf status qualifier
++ * @port_handle: handle for port
++ * @lun_handle: handle for LUN
+  */
+ struct zfcp_dbf_hba_res {
+ 	u64 req_issued;
+@@ -158,6 +162,7 @@ struct zfcp_dbf_hba_uss {
+  * @ZFCP_DBF_HBA_RES: response trace record
+  * @ZFCP_DBF_HBA_USS: unsolicited status trace record
+  * @ZFCP_DBF_HBA_BIT: bit error trace record
++ * @ZFCP_DBF_HBA_BASIC: basic adapter event, only trace tag, no other data
+  */
+ enum zfcp_dbf_hba_id {
+ 	ZFCP_DBF_HBA_RES	= 1,
+@@ -176,6 +181,9 @@ enum zfcp_dbf_hba_id {
+  * @fsf_seq_no: fsf sequence number
+  * @pl_len: length of payload stored as zfcp_dbf_pay
+  * @u: record type specific data
++ * @u.res: data for fsf responses
++ * @u.uss: data for unsolicited status buffer
++ * @u.be:  data for bit error unsolicited status buffer
+  */
+ struct zfcp_dbf_hba {
+ 	u8 id;
+diff --git a/drivers/s390/scsi/zfcp_fc.h b/drivers/s390/scsi/zfcp_fc.h
+index 3cd74729cfb9..6902ae1f8e4f 100644
+--- a/drivers/s390/scsi/zfcp_fc.h
++++ b/drivers/s390/scsi/zfcp_fc.h
+@@ -121,9 +121,24 @@ struct zfcp_fc_rspn_req {
+ /**
+  * struct zfcp_fc_req - Container for FC ELS and CT requests sent from zfcp
+  * @ct_els: data required for issuing fsf command
+- * @sg_req: scatterlist entry for request data
+- * @sg_rsp: scatterlist entry for response data
+- * @u: request specific data
++ * @sg_req: scatterlist entry for request data, refers to embedded @u submember
++ * @sg_rsp: scatterlist entry for response data, refers to embedded @u submember
++ * @u: request and response specific data
++ * @u.adisc: ADISC specific data
++ * @u.adisc.req: ADISC request
++ * @u.adisc.rsp: ADISC response
++ * @u.gid_pn: GID_PN specific data
++ * @u.gid_pn.req: GID_PN request
++ * @u.gid_pn.rsp: GID_PN response
++ * @u.gpn_ft: GPN_FT specific data
++ * @u.gpn_ft.sg_rsp2: GPN_FT response, not embedded here, allocated elsewhere
++ * @u.gpn_ft.req: GPN_FT request
++ * @u.gspn: GSPN specific data
++ * @u.gspn.req: GSPN request
++ * @u.gspn.rsp: GSPN response
++ * @u.rspn: RSPN specific data
++ * @u.rspn.req: RSPN request
++ * @u.rspn.rsp: RSPN response
+  */
+ struct zfcp_fc_req {
+ 	struct zfcp_fsf_ct_els				ct_els;
+diff --git a/drivers/s390/scsi/zfcp_fsf.h b/drivers/s390/scsi/zfcp_fsf.h
+index 535628b92f0a..2c658b66318c 100644
+--- a/drivers/s390/scsi/zfcp_fsf.h
++++ b/drivers/s390/scsi/zfcp_fsf.h
+@@ -438,8 +438,8 @@ struct zfcp_blk_drv_data {
+ 
+ /**
+  * struct zfcp_fsf_ct_els - zfcp data for ct or els request
+- * @req: scatter-gather list for request
+- * @resp: scatter-gather list for response
++ * @req: scatter-gather list for request, points to &zfcp_fc_req.sg_req or BSG
++ * @resp: scatter-gather list for response, points to &zfcp_fc_req.sg_rsp or BSG
+  * @handler: handler function (called for response to the request)
+  * @handler_data: data passed to handler function
+  * @port: Optional pointer to port for zfcp internal ELS (only test link ADISC)
+diff --git a/drivers/s390/scsi/zfcp_qdio.h b/drivers/s390/scsi/zfcp_qdio.h
+index 886c662cc154..2a816a37b3c0 100644
+--- a/drivers/s390/scsi/zfcp_qdio.h
++++ b/drivers/s390/scsi/zfcp_qdio.h
+@@ -30,6 +30,8 @@
+  * @req_q_full: queue full incidents
+  * @req_q_wq: used to wait for SBAL availability
+  * @adapter: adapter used in conjunction with this qdio structure
++ * @max_sbale_per_sbal: qdio limit per sbal
++ * @max_sbale_per_req: qdio limit per request
+  */
+ struct zfcp_qdio {
+ 	struct qdio_buffer	*res_q[QDIO_MAX_BUFFERS_PER_Q];
+@@ -70,7 +72,7 @@ struct zfcp_qdio_req {
+ /**
+  * zfcp_qdio_sbale_req - return pointer to sbale on req_q for a request
+  * @qdio: pointer to struct zfcp_qdio
+- * @q_rec: pointer to struct zfcp_qdio_req
++ * @q_req: pointer to struct zfcp_qdio_req
+  * Returns: pointer to qdio_buffer_element (sbale) structure
+  */
+ static inline struct qdio_buffer_element *
+@@ -82,7 +84,7 @@ zfcp_qdio_sbale_req(struct zfcp_qdio *qdio, struct zfcp_qdio_req *q_req)
+ /**
+  * zfcp_qdio_sbale_curr - return current sbale on req_q for a request
+  * @qdio: pointer to struct zfcp_qdio
+- * @fsf_req: pointer to struct zfcp_fsf_req
++ * @q_req: pointer to struct zfcp_qdio_req
+  * Returns: pointer to qdio_buffer_element (sbale) structure
+  */
+ static inline struct qdio_buffer_element *
+@@ -135,6 +137,8 @@ void zfcp_qdio_req_init(struct zfcp_qdio *qdio, struct zfcp_qdio_req *q_req,
+  * zfcp_qdio_fill_next - Fill next sbale, only for single sbal requests
+  * @qdio: pointer to struct zfcp_qdio
+  * @q_req: pointer to struct zfcp_queue_req
++ * @data: pointer to data
++ * @len: length of data
+  *
+  * This is only required for single sbal requests, calling it when
+  * wrapping around to the next sbal is a bug.
+@@ -182,6 +186,7 @@ int zfcp_qdio_sg_one_sbale(struct scatterlist *sg)
+ 
+ /**
+  * zfcp_qdio_skip_to_last_sbale - skip to last sbale in sbal
++ * @qdio: pointer to struct zfcp_qdio
+  * @q_req: The current zfcp_qdio_req
+  */
+ static inline
+diff --git a/drivers/s390/scsi/zfcp_reqlist.h b/drivers/s390/scsi/zfcp_reqlist.h
+index 59a943c0d51d..9b8ff249e31c 100644
+--- a/drivers/s390/scsi/zfcp_reqlist.h
++++ b/drivers/s390/scsi/zfcp_reqlist.h
+@@ -17,7 +17,7 @@
+ /**
+  * struct zfcp_reqlist - Container for request list (reqlist)
+  * @lock: Spinlock for protecting the hash list
+- * @list: Array of hashbuckets, each is a list of requests in this bucket
++ * @buckets: Array of hashbuckets, each is a list of requests in this bucket
+  */
+ struct zfcp_reqlist {
+ 	spinlock_t lock;

--- a/tests/assets/patches/4.18-079-171-SCSI-fix-queue-cleanup-race-before-queue-initialization-is-done.patch
+++ b/tests/assets/patches/4.18-079-171-SCSI-fix-queue-cleanup-race-before-queue-initialization-is-done.patch
@@ -1,0 +1,160 @@
+From patchwork Mon Nov 19 16:27:55 2018
+Content-Type: text/plain; charset="utf-8"
+MIME-Version: 1.0
+Content-Transfer-Encoding: 7bit
+X-Patchwork-Submitter: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+X-Patchwork-Id: 10689205
+Return-Path: <linux-scsi-owner@kernel.org>
+Received: from mail.wl.linuxfoundation.org (pdx-wl-mail.web.codeaurora.org
+ [172.30.200.125])
+	by pdx-korg-patchwork-2.web.codeaurora.org (Postfix) with ESMTP id 08D9614D6
+	for <patchwork-linux-scsi@patchwork.kernel.org>;
+ Mon, 19 Nov 2018 17:49:03 +0000 (UTC)
+Received: from mail.wl.linuxfoundation.org (localhost [127.0.0.1])
+	by mail.wl.linuxfoundation.org (Postfix) with ESMTP id E83632A35F
+	for <patchwork-linux-scsi@patchwork.kernel.org>;
+ Mon, 19 Nov 2018 17:49:02 +0000 (UTC)
+Received: by mail.wl.linuxfoundation.org (Postfix, from userid 486)
+	id D9CC02A388; Mon, 19 Nov 2018 17:49:02 +0000 (UTC)
+X-Spam-Checker-Version: SpamAssassin 3.3.1 (2010-03-16) on
+	pdx-wl-mail.web.codeaurora.org
+X-Spam-Level: 
+X-Spam-Status: No, score=-7.9 required=2.0 tests=BAYES_00,DKIM_SIGNED,
+	DKIM_VALID,MAILING_LIST_MULTI,RCVD_IN_DNSWL_HI autolearn=ham version=3.3.1
+Received: from vger.kernel.org (vger.kernel.org [209.132.180.67])
+	by mail.wl.linuxfoundation.org (Postfix) with ESMTP id 5A03B2A35F
+	for <patchwork-linux-scsi@patchwork.kernel.org>;
+ Mon, 19 Nov 2018 17:49:02 +0000 (UTC)
+Received: (majordomo@vger.kernel.org) by vger.kernel.org via listexpand
+        id S2388231AbeKTDI3 (ORCPT
+        <rfc822;patchwork-linux-scsi@patchwork.kernel.org>);
+        Mon, 19 Nov 2018 22:08:29 -0500
+Received: from mail.kernel.org ([198.145.29.99]:43010 "EHLO mail.kernel.org"
+        rhost-flags-OK-OK-OK-OK) by vger.kernel.org with ESMTP
+        id S2387795AbeKTDI2 (ORCPT <rfc822;linux-scsi@vger.kernel.org>);
+        Mon, 19 Nov 2018 22:08:28 -0500
+Received: from localhost (5356596B.cm-6-7b.dynamic.ziggo.nl [83.86.89.107])
+        (using TLSv1.2 with cipher ECDHE-RSA-AES256-GCM-SHA384 (256/256 bits))
+        (No client certificate requested)
+        by mail.kernel.org (Postfix) with ESMTPSA id 875C920C01;
+        Mon, 19 Nov 2018 16:44:16 +0000 (UTC)
+DKIM-Signature: v=1; a=rsa-sha256; c=relaxed/simple; d=kernel.org;
+        s=default; t=1542645857;
+        bh=dI1UPSFfo805wVZNkkEoK02gcI6wVxdmW+UmyfvB5Ww=;
+        h=From:To:Cc:Subject:Date:In-Reply-To:References:From;
+        b=Qvn4a9OfpgAyeg5deoxbCfhBwsfc9OQbY8NQj07q+of0Y2VSLZAK8T8x9vQlfmqAY
+         UqvLbX7leSoV5sny4XwPzorEti8UGyQAYQQMiOWg6yEviy0TJTVBpFtShYpW8tid94
+         aYao2gNQ2adn8VCf4iuZqcTvnUDjVNErVjdZRJp0=
+From: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+To: linux-kernel@vger.kernel.org
+Cc: Greg Kroah-Hartman <gregkh@linuxfoundation.org>,
+        stable@vger.kernel.org, Andrew Jones <drjones@redhat.com>,
+        Bart Van Assche <bart.vanassche@wdc.com>,
+        linux-scsi@vger.kernel.org,
+        "Martin K. Petersen" <martin.petersen@oracle.com>,
+        Christoph Hellwig <hch@lst.de>,
+        "James E.J. Bottomley" <jejb@linux.vnet.ibm.com>,
+        "jianchao.wang" <jianchao.w.wang@oracle.com>,
+        Ming Lei <ming.lei@redhat.com>, Jens Axboe <axboe@kernel.dk>
+Subject: [PATCH 4.18 079/171] SCSI: fix queue cleanup race before queue
+ initialization is done
+Date: Mon, 19 Nov 2018 17:27:55 +0100
+Message-Id: <20181119162632.278437995@linuxfoundation.org>
+X-Mailer: git-send-email 2.19.1
+In-Reply-To: <20181119162618.909354448@linuxfoundation.org>
+References: <20181119162618.909354448@linuxfoundation.org>
+User-Agent: quilt/0.65
+X-stable: review
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Sender: linux-scsi-owner@vger.kernel.org
+Precedence: bulk
+List-ID: <linux-scsi.vger.kernel.org>
+X-Mailing-List: linux-scsi@vger.kernel.org
+X-Virus-Scanned: ClamAV using ClamSMTP
+
+4.18-stable review patch.  If anyone has any objections, please let me know.
+
+------------------
+
+From: Ming Lei <ming.lei@redhat.com>
+
+commit 8dc765d438f1e42b3e8227b3b09fad7d73f4ec9a upstream.
+
+c2856ae2f315d ("blk-mq: quiesce queue before freeing queue") has
+already fixed this race, however the implied synchronize_rcu()
+in blk_mq_quiesce_queue() can slow down LUN probe a lot, so caused
+performance regression.
+
+Then 1311326cf4755c7 ("blk-mq: avoid to synchronize rcu inside blk_cleanup_queue()")
+tried to quiesce queue for avoiding unnecessary synchronize_rcu()
+only when queue initialization is done, because it is usual to see
+lots of inexistent LUNs which need to be probed.
+
+However, turns out it isn't safe to quiesce queue only when queue
+initialization is done. Because when one SCSI command is completed,
+the user of sending command can be waken up immediately, then the
+scsi device may be removed, meantime the run queue in scsi_end_request()
+is still in-progress, so kernel panic can be caused.
+
+In Red Hat QE lab, there are several reports about this kind of kernel
+panic triggered during kernel booting.
+
+This patch tries to address the issue by grabing one queue usage
+counter during freeing one request and the following run queue.
+
+Fixes: 1311326cf4755c7 ("blk-mq: avoid to synchronize rcu inside blk_cleanup_queue()")
+Cc: Andrew Jones <drjones@redhat.com>
+Cc: Bart Van Assche <bart.vanassche@wdc.com>
+Cc: linux-scsi@vger.kernel.org
+Cc: Martin K. Petersen <martin.petersen@oracle.com>
+Cc: Christoph Hellwig <hch@lst.de>
+Cc: James E.J. Bottomley <jejb@linux.vnet.ibm.com>
+Cc: stable <stable@vger.kernel.org>
+Cc: jianchao.wang <jianchao.w.wang@oracle.com>
+Signed-off-by: Ming Lei <ming.lei@redhat.com>
+Signed-off-by: Jens Axboe <axboe@kernel.dk>
+Signed-off-by: Greg Kroah-Hartman <gregkh@linuxfoundation.org>
+---
+ block/blk-core.c        |    5 ++---
+ drivers/scsi/scsi_lib.c |    8 ++++++++
+ 2 files changed, 10 insertions(+), 3 deletions(-)
+
+--- a/block/blk-core.c
++++ b/block/blk-core.c
+@@ -793,9 +793,8 @@ void blk_cleanup_queue(struct request_qu
+ 	 * dispatch may still be in-progress since we dispatch requests
+ 	 * from more than one contexts.
+ 	 *
+-	 * No need to quiesce queue if it isn't initialized yet since
+-	 * blk_freeze_queue() should be enough for cases of passthrough
+-	 * request.
++	 * We rely on driver to deal with the race in case that queue
++	 * initialization isn't done.
+ 	 */
+ 	if (q->mq_ops && blk_queue_init_done(q))
+ 		blk_mq_quiesce_queue(q);
+--- a/drivers/scsi/scsi_lib.c
++++ b/drivers/scsi/scsi_lib.c
+@@ -696,6 +696,12 @@ static bool scsi_end_request(struct requ
+ 		 */
+ 		scsi_mq_uninit_cmd(cmd);
+ 
++		/*
++		 * queue is still alive, so grab the ref for preventing it
++		 * from being cleaned up during running queue.
++		 */
++		percpu_ref_get(&q->q_usage_counter);
++
+ 		__blk_mq_end_request(req, error);
+ 
+ 		if (scsi_target(sdev)->single_lun ||
+@@ -703,6 +709,8 @@ static bool scsi_end_request(struct requ
+ 			kblockd_schedule_work(&sdev->requeue_work);
+ 		else
+ 			blk_mq_run_hw_queues(q, true);
++
++		percpu_ref_put(&q->q_usage_counter);
+ 	} else {
+ 		unsigned long flags;
+ 

--- a/tests/assets/patches/raw.diff
+++ b/tests/assets/patches/raw.diff
@@ -1,0 +1,51 @@
+diff -ru kernel.old/lib/iomap.c kernel.new/lib/iomap.c
+--- kernel.old/lib/iomap.c	2018-11-20 13:15:35.617581159 +0200
++++ kernel.new/lib/iomap.c	2018-11-20 13:16:52.497062651 +0200
+@@ -225,23 +225,6 @@
+ EXPORT_SYMBOL(iowrite16_rep);
+ EXPORT_SYMBOL(iowrite32_rep);
+ 
+-#ifdef CONFIG_HAS_IOPORT_MAP
+-/* Create a virtual mapping cookie for an IO port range */
+-void __iomem *ioport_map(unsigned long port, unsigned int nr)
+-{
+-	if (port > PIO_MASK)
+-		return NULL;
+-	return (void __iomem *) (unsigned long) (port + PIO_OFFSET);
+-}
+-
+-void ioport_unmap(void __iomem *addr)
+-{
+-	/* Nothing to do */
+-}
+-EXPORT_SYMBOL(ioport_map);
+-EXPORT_SYMBOL(ioport_unmap);
+-#endif /* CONFIG_HAS_IOPORT_MAP */
+-
+ #ifdef CONFIG_PCI
+ /* Hide the details if this is a MMIO or PIO address space and just do what
+  * you expect in the correct way. */
+diff -ru kernel.old/lib/llist.c kernel.new/lib/llist.c
+--- kernel.old/lib/llist.c	2018-11-20 13:15:46.001512030 +0200
++++ kernel.new/lib/llist.c	2018-11-20 13:22:45.870525761 +0200
+@@ -46,7 +46,6 @@
+ 
+ 	return !first;
+ }
+-EXPORT_SYMBOL_GPL(llist_add_batch);
+ 
+ /**
+  * llist_del_first - delete the first entry of lock-less list
+@@ -79,7 +78,6 @@
+ 
+ 	return entry;
+ }
+-EXPORT_SYMBOL_GPL(llist_del_first);
+ 
+ /**
+  * llist_reverse_order - reverse order of a llist chain
+@@ -101,4 +99,3 @@
+ 
+ 	return new_head;
+ }
+-EXPORT_SYMBOL_GPL(llist_reverse_order);

--- a/tests/test_targeted.py
+++ b/tests/test_targeted.py
@@ -58,6 +58,15 @@ class TargetedTest(unittest.TestCase):
             'fs/ext4/inode.c',
             'fs/ext4/ioctl.c',
             'fs/xfs/xfs_log.c',
+            'block/blk-core.c',
+            'drivers/scsi/scsi_lib.c',
+            'drivers/s390/scsi/zfcp_dbf.h',
+            'drivers/s390/scsi/zfcp_fc.h',
+            'drivers/s390/scsi/zfcp_fsf.h',
+            'drivers/s390/scsi/zfcp_qdio.h',
+            'drivers/s390/scsi/zfcp_reqlist.h',
+            'lib/iomap.c',
+            'lib/llist.c',
         }
         self.assertSequenceEqual(
             expected_value,


### PR DESCRIPTION
Extract files being changed from lines starting with '---' and '+++',
instead of 'diff --git ...' lines, in patches. Ignore any matches
before the '---' line.

This adds basic support for mbox'es and raw diffs.