### PR TITLE
feature: allow to enable/disable tests

### DIFF
--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -17,7 +17,7 @@ import argparse
 import os
 import sys
 import logging
-from kpet import run, tree
+from kpet import run, tree, tests
 
 
 # (argparse uses help as parameter) pylint: disable=redefined-builtin
@@ -141,6 +141,55 @@ def build_tree_command(cmds_parser, common_parser):
     )
 
 
+def build_tests_comamnd(cmds_parser, common_parser):
+    """Build the argument parser for the enable command"""
+    _, action_subparser = _build_command(
+        cmds_parser,
+        common_parser,
+        "tests",
+        help='Modify tests, default action is "enable".',
+    )
+    tests_parser = action_subparser.add_parser(
+        "enable",
+        help='(re)Enable a test',
+        parents=[common_parser],
+    )
+
+    tests_disable_parser = action_subparser.add_parser(
+        "disable",
+        help='Disable a test',
+        parents=[common_parser],
+    )
+
+    tests_disable_parser.add_argument(
+        "test",
+        help='Test name to disable or enable.'
+    )
+
+    tests_parser.add_argument(
+        "test",
+        help='Test name to disable or enable.'
+    )
+
+    tests_disable_parser.add_argument(
+        "--branch",
+        "-b",
+        help='If set, disable/enable test remotely on a specified branch,'
+             ' instead of locally. Set env GITLAB_URL, GITLAB_PRIVATE_TOKEN'
+             ' accordingly.',
+        default=None
+    )
+
+    tests_parser.add_argument(
+        "--branch",
+        "-b",
+        help='If set, disable/enable test remotely on a specified branch,'
+             ' instead of locally. Set env GITLAB_URL, GITLAB_PRIVATE_TOKEN'
+             ' accordingly.',
+        default=None
+    )
+
+
 def exec_command(args, commands):
     """Call the associated command handler"""
     try:
@@ -175,11 +224,13 @@ def main(args=None):
     build_run_command(cmds_parser, common_parser)
     build_tree_command(cmds_parser, common_parser)
     build_arch_command(cmds_parser, common_parser)
+    build_tests_comamnd(cmds_parser, common_parser)
 
     args = parser.parse_args(args)
     commands = {
         'help': [parser.print_help],
         'run': [run.main, args],
         'tree': [tree.main, args],
+        'tests': [tests.main, args]
     }
     exec_command(args, commands)

--- a/kpet/tests.py
+++ b/kpet/tests.py
@@ -1,0 +1,242 @@
+# Copyright (c) 2018 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""Module where the `tree` command is implemented"""
+from __future__ import print_function
+
+import json
+import logging
+import os
+
+from six import moves
+import gitlab
+
+
+from kpet import utils
+
+
+class TestEnabler(object):
+    """ A class to enable/disable tests by modyfying layout/layout.json."""
+    # pylint: disable=useless-object-inheritance
+    def __init__(self, db_path):
+        # path to layout file of kpet-db
+        self.layout_file = os.path.join('layout', 'layout.json')
+        self.layout_path = os.path.join(db_path, self.layout_file)
+
+        # the parsed json layout.json
+        self.obj = None
+        # a portion of layout.json - enabled testsuites
+        self.testsuites = None
+        # a portion of layout.json - disabled testsuites
+        self.testsuites_disabled = None
+
+        # gitlab project, to be used to change remote file if
+        # 'branch' isn't empty
+        self.project = None
+
+        gitlab_url = os.environ['GITLAB_URL']
+        private_token = os.environ['GITLAB_PRIVATE_TOKEN']
+
+        self.gitlab_instance = gitlab.Gitlab(gitlab_url,
+                                             private_token=private_token,
+                                             api_version=str(4))
+
+    def get_testsuites(self):
+        """ Load layout.json and populate testsuites, testsuites_disabled class
+            attributes.
+        """
+
+        with open(self.layout_path, 'r') as handle:
+            self.obj = json.load(handle)
+        assert self.obj['schema']['version'] == 1
+
+        # load a portion of the obj parsed json
+        self.testsuites = self.obj['testsuites']
+
+        # create empty testsuites_disabled if necessary
+        try:
+            self.testsuites_disabled = self.obj['testsuites_disabled']
+        except KeyError:
+            self.testsuites_disabled = {}
+
+    def check_test_exists(self, testname):
+        """ Raise error if the testname is not present in parsed json."""
+        if testname not in self.testsuites.keys() and testname not in \
+                self.testsuites_disabled.keys():
+            raise RuntimeError('Test not found')
+
+    def move_test(self, ffrom, move_to, testname):
+        """ Move test from one dict to another, then set self.obj.
+
+        """
+        # add test to disabled
+        move_to[testname] = ffrom[testname]
+
+        # remove test from ffrom dict
+        ffrom.pop(testname)
+
+        self.obj['testsuites'] = self.testsuites
+        self.obj['testsuites_disabled'] = self.testsuites_disabled
+
+    def enable_disable_test(self, testname, action):
+        """
+        Enable or disable a test by modifying layout/layout.json of set KPET-db
+        db_path.
+        This method checks if test exists, is already disabled/enabled.
+        If all is good, the test is moved from disabled to enable or
+        vice-versa. As a result, the json layout file is recreated.
+
+        Args:
+            testname: a short name of the test to enable/disable
+            action: str - 'enable' or 'disable'
+        """
+
+        self.check_test_exists(testname)
+
+        # let user know
+        logging.info('%s-ing "%s" testcase', action, testname)
+
+        ffrom = self.testsuites_disabled if action == 'enable' else \
+            self.testsuites
+
+        move_to = self.testsuites if action == 'enable' else \
+            self.testsuites_disabled
+
+        if testname in move_to.keys() or testname not in ffrom.keys():
+            logging.warning('Test already %sd', action)
+            return
+
+        # enable test by moving it from testsuites_disabled to testsuites
+        self.move_test(ffrom, move_to, testname)
+
+        # write changes: recreate file layout/layout.json
+        with open(self.layout_path, 'w') as handle:
+            json.dump(self.obj, handle, indent=4)
+            handle.write('\n')
+
+    def remote_init(self):
+        """ Pull GITLAB_URL and GITLAB_PRIVATE_TOKEN from env to create gitlab
+            object instance, then get 'cki-project/kpet-db' project.
+
+            NOTE: the gitlab import is kept here, so it's possible to test it.
+
+            Raises: ImportError if we don't have gitlab.
+        """
+
+        self.project = self.gitlab_instance.projects.get('cki-project/kpet-db')
+
+    def get_remote_file(self, branch, ffile):
+        """ Download a file from <branch> of a remote project set in
+            remote_init().
+        Args:
+            branch: A branch to use as ref
+            ffile:  A path to a file to download
+
+        Returns: file content
+
+        """
+        ffile = self.project.files.get(file_path=ffile, ref=branch)
+
+        return ffile
+
+    def create_update_commit(self, branch, commit_message, ffile, content):
+        """
+        Create an update commit on a branch.
+
+        Args:
+            branch:         The branch to use as ref
+            commit_message: The message of the newly created commit
+            ffile:          A path to the file to update on branch
+            content:        The new ffile content
+
+
+            title:   String to use as the commit message title.
+        """
+
+        data = {
+            'branch': branch,
+            'commit_message': commit_message,
+            "actions": [
+                {
+                    "action": "update",
+                    "file_path": ffile,
+                    "content": content
+                },
+            ]
+
+        }
+        self.project.commits.create(data)
+
+
+def prompt_to_write(branch, test_enabler, ffile):
+    """ Prompt user for confirmation to update remote file.
+
+    Args:
+        branch      : The branch to update with file content
+        test_enabler: TestEnabler instance
+        ffile       : A file with the update content
+
+    """
+    while True:
+        choice = moves.input('Push to remote [y/n]?').lower()
+        if choice == 'y':
+            msg = "update {}".format(test_enabler.layout_file)
+            with open(ffile, 'r') as handle:
+                test_enabler.create_update_commit(branch, msg,
+                                                  test_enabler.layout_file,
+                                                  handle.read())
+
+        if choice in ['y', 'n']:
+            break
+
+
+def do_enable(args, test_enabler):
+    """ Enable or disable a test based on args.
+    Args:
+        args:         argaparse.Namespace (parsed arguments)
+        test_enabler: TestEnabler instance
+    """
+    branch = args.branch
+    if not branch:
+        # move test locally
+        test_enabler.get_testsuites()
+
+        test_enabler.enable_disable_test(args.test, args.action)
+    elif branch:
+        test_enabler.remote_init()
+        layout_file = test_enabler.layout_file
+        str_layout = test_enabler.get_remote_file(branch, layout_file)
+
+        with utils.tempfile_from_string(str_layout.encode()) as ffile:
+            test_enabler.layout_path = ffile
+
+            # load json (the above file we downloaded)
+            test_enabler.get_testsuites()
+
+            # move test locally on file f we downloaded
+            test_enabler.enable_disable_test(args.test, args.action)
+
+            # confirm with user and push
+            prompt_to_write(branch, test_enabler, ffile)
+
+
+def main(args):
+    """Main function for the `tests` command"""
+
+    if args.action in ['enable', 'disable']:
+        test_enabler = TestEnabler(args.db)
+
+        do_enable(args, test_enabler)
+    else:
+        logging.error('invalid arguments use kpet -h')
+        utils.raise_action_not_found(args.action, args.command)

--- a/kpet/utils.py
+++ b/kpet/utils.py
@@ -13,6 +13,7 @@
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Utils used across kpet's commands"""
 import os
+from contextlib import contextmanager
 try:
     from urllib.parse import urlparse
 except ImportError:
@@ -21,6 +22,20 @@ import tempfile
 import requests
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from kpet.exceptions import ActionNotFound
+
+
+@contextmanager
+def tempfile_from_string(data):
+    """ Create a temporary file wrapped in contextmanager. The file is placed
+        in /tmp/<temporaryName> and destroyed once we exit context manager.
+    """
+    temp = tempfile.NamedTemporaryFile(delete=False)
+    temp.write(data)
+    temp.close()
+    try:
+        yield temp.name
+    finally:
+        os.unlink(temp.name)
 
 
 def get_jinja_template(tree, dbdir):

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ python_requires = >= 2.7, != 3.0.*, != 3.1.*, != 3.2.*
 test_suite = tests
 install_requires = requests
                    Jinja2
+                   python-gitlab
 tests_require = mock
 
 [options.extras_require]

--- a/tests/test_tests.py
+++ b/tests/test_tests.py
@@ -1,0 +1,195 @@
+# Copyright (c) 2018 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""Test cases for run module"""
+
+import os
+import unittest
+import tempfile
+import shutil
+import mock
+
+from kpet import exceptions
+import kpet
+
+
+class FakeGitLabCommits(object):
+    """ A fake GitLabCommits class for purposes of this testing."""
+    # pylint: disable=useless-object-inheritance,too-few-public-methods
+    def __init__(self):
+        self._commits = []
+
+    def create(self, data):
+        """ A fake method to create a commit."""
+        self._commits.append(data)
+
+
+class FakeGitLabProject(object):
+    """ A fake GitLabProject class for purposes of this testing."""
+    # pylint: disable=useless-object-inheritance,too-few-public-methods
+    def __init__(self):
+        self.commits = FakeGitLabCommits()
+        self.files = FakeGitFiles()
+
+
+class FakeGitFiles(object):
+    """ A fake GitFiles class for purposes of this testing."""
+    # pylint: disable=useless-object-inheritance,too-few-public-methods
+    # pylint: disable=unused-argument,no-self-use
+    def __init__(self):
+        self.files = {}
+
+    def get(self, file_path=None, ref=None):
+        """ A fake method to load asset file instead of downloading it.
+            Args:
+                file_path: a path to a file relative to tree root
+                ref:       a branch reference
+        """
+        path = os.path.join(os.path.dirname(__file__), 'assets', file_path)
+        handle = open(path, 'r')
+        content = handle.read()
+        handle.close()
+
+        return content
+
+
+class FakeGitLab(object):
+    """ A fake GitLab class for purposes of this testing."""
+    # pylint: disable=useless-object-inheritance,too-few-public-methods
+    def __init__(self):
+        self.projects = {}
+
+    def add_project(self, project_name):
+        """ A fake method to add a project.
+            Args:
+                project_name: name of the project to add
+        """
+        self.projects[project_name] = FakeGitLabProject()
+
+
+class TestsTest(unittest.TestCase):
+    """ Test cases for tests module."""
+
+    def setUp(self):
+        """ Ensure test methods have what they need for testing."""
+        os.environ.update({'GITLAB_URL': 'http://gitlab.test',
+                           'GITLAB_PRIVATE_TOKEN': 'private-token'})
+
+        dbdir = os.path.join(os.path.dirname(__file__), 'assets')
+        tmpdir = tempfile.mkdtemp()
+        self.tmp_dbdir = os.path.join(tmpdir, 'db')
+        shutil.copytree(dbdir, self.tmp_dbdir)
+        with open(os.path.join(self.tmp_dbdir, 'templates', 'file.txt'), 'w'):
+            pass
+
+    def tearDown(self):
+        """ Cleanup after testing."""
+        del os.environ['GITLAB_URL']
+        del os.environ['GITLAB_PRIVATE_TOKEN']
+
+    def get_standard_mock_args(self, action, testname, branch=None):
+        """ Create mocked arguments for main of uut.
+            Args:
+                action:   'enable' or 'disable' a test
+                testname: a test to enable or disable
+                branch:   remote branch to update, or None to work locally
+        """
+        mock_args = mock.Mock()
+
+        mock_args.db = self.tmp_dbdir
+        mock_args.action = action
+        mock_args.test = testname
+        mock_args.branch = branch
+
+        return mock_args
+
+    @mock.patch('logging.error')
+    def test_actions(self, mock_logging):
+        """ Check the proper exception is raised when action is not found."""
+        # pylint: disable=unused-argument
+        mock_args = mock.Mock()
+        self.assertRaises(exceptions.ActionNotFound, kpet.tests.main,
+                          mock_args)
+
+    @mock.patch('logging.warning')
+    def test_disable_invalid(self, mock_logging):
+        """ Ensure that disabling non-existing-test fails."""
+        # pylint: disable=unused-argument
+        mock_args = self.get_standard_mock_args('disable', 'non-existing-test')
+
+        with self.assertRaises(RuntimeError):
+            kpet.tests.main(mock_args)
+
+    def test_remote(self):
+        """ Ensure that main works for remote operation."""
+        test_enabler = kpet.tests.TestEnabler(self.tmp_dbdir)
+
+        test_enabler.gitlab_instance = FakeGitLab()
+        test_enabler.gitlab_instance.add_project('cki-project/kpet-db')
+
+        mock_args = self.get_standard_mock_args('disable', 'fs', 'master')
+
+        with mock.patch('six.moves.input',
+                        mock.MagicMock(name='input', side_effect=['y',
+                                                                  EOFError])):
+            kpet.tests.do_enable(mock_args, test_enabler)
+
+    @mock.patch('logging.warning')
+    def test_main_calls_enable(self, mock_logging):
+        """Verify main() calls enable local functions it should."""
+        # pylint: disable=unused-argument
+
+        mock_args = self.get_standard_mock_args('enable', 'fs')
+        kpet.tests.main(mock_args)
+
+    @mock.patch('logging.warning')
+    def test_main_calls_disable(self, mock_logging):
+        """Verify main() calls disable local functions it should."""
+        # pylint: disable=unused-argument
+
+        mock_args = self.get_standard_mock_args('disable', 'fs')
+        kpet.tests.main(mock_args)
+
+    def test_create_update_commit(self):
+        """ Ensure TestEnabler's remote_init() doesn't crash."""
+        test_enabler = kpet.tests.TestEnabler(self.tmp_dbdir)
+        test_enabler.gitlab_instance = FakeGitLab()
+
+        test_enabler.remote_init()
+
+    def test_move(self):
+        """ Ensure that move_test() method of TestEnabler works."""
+        test_enabler = kpet.tests.TestEnabler(self.tmp_dbdir)
+
+        test_enabler.testsuites = {'data': 0}
+        test_enabler.testsuites_disabled = {'data_disabled': 0}
+
+        test_enabler.obj = {}
+        test_enabler.obj['testsuites'] = {}
+        test_enabler.obj['testsuites_disabled'] = {}
+
+        ffrom = {'a': 0}
+        move_to = {}
+
+        test_enabler.move_test(ffrom, move_to, 'a')
+
+        self.assertEqual(ffrom, {})
+        self.assertEqual(move_to, {'a': 0})
+        self.assertEqual(test_enabler.obj['testsuites_disabled'],
+                         test_enabler.testsuites_disabled)
+        self.assertEqual(test_enabler.obj['testsuites'],
+                         test_enabler.testsuites)
+        self.assertEqual(test_enabler.obj['testsuites_disabled'],
+                         {'data_disabled': 0})
+        self.assertEqual(test_enabler.obj['testsuites'],
+                         {'data': 0})

--- a/tox.ini
+++ b/tox.ini
@@ -28,4 +28,5 @@ basepython =
 commands =
     # Disable R0801 in pylint that checks for duplicate content in multiple
     # files. See https://github.com/PyCQA/pylint/issues/214 for details.
-    pylint -d R0801 --ignored-classes=responses kpet tests
+    # Disable E0012 because of python2/3 pylint incompatibility.
+    pylint -d E0012 -d R0801 --ignored-classes=responses kpet tests


### PR DESCRIPTION
This patch adds 'kpet tests enable/disable' commands.
The commands modify either a local layout file relative to --db <arg>,
or remote layout file on cki-project/kpet-db:<branch> (specified by -b
<branch>).

If you want to update a remote project using -b, env. variables
GITLAB_URL and GITLAB_PRIVATE_TOKEN have to be set

The tests are disabled/enabled by moving tests (to/from
testsuites and testsuites_disabled (a new dict) inside layout/layout.json
of kpet-db.

Signed-off-by: Jakub Racek <jracek@redhat.com>