### PR TITLE
feature: soaking attributes for Beaker XMLs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ kpet.egg-info
 .tox/
 .coverage
 .eggs/
+.idea/

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -17,6 +17,7 @@ import tempfile
 import unittest
 import mock
 from kpet import run, utils, exceptions
+from kpet import targeted
 
 
 class RunTest(unittest.TestCase):
@@ -95,9 +96,13 @@ class RunTest(unittest.TestCase):
         """
         Check print_test_cases prints the suggested test cases.
         """
-        mock_get_test_cases.return_value = ['default/ltplite', 'fs/xfs']
+        mock_get_test_cases.return_value = [
+            targeted.TestCase('default/ltplite', []),
+            targeted.TestCase('fs/xfs', [])
+        ]
         with mock.patch('sys.stdout') as mock_stdout:
             run.print_test_cases("", "")
+
         self.assertEqual('default/ltplite',
                          mock_stdout.write.call_args_list[0][0][0])
         self.assertEqual('fs/xfs',
@@ -108,6 +113,23 @@ class RunTest(unittest.TestCase):
         """
         Check get_test_cases returns the suggested test cases.
         """
-        mock_get_test_cases.return_value = ['default/ltplite', 'fs/xfs']
+        mock_get_test_cases.return_value = [
+            targeted.TestCase('default/ltplite', []),
+            targeted.TestCase('fs/xfs', [])
+        ]
         test_cases = run.get_test_cases("", "")
         self.assertEqual(mock_get_test_cases.return_value, test_cases)
+
+    def test_get_soaking_inner(self):
+        """ Ensure that get_soaking_inner() works."""
+        tasks = ['test', 'jest', 'quest']
+        is_soaking = [1, 0, None]
+
+        result = run.get_soaking_inner('test', tasks, is_soaking)
+        self.assertEqual(result, 'soaking="1"')
+
+        result = run.get_soaking_inner('jest', tasks, is_soaking)
+        self.assertEqual(result, 'soaking="0"')
+
+        result = run.get_soaking_inner('quest', tasks, is_soaking)
+        self.assertEqual(result, '')

--- a/tests/test_targeted.py
+++ b/tests/test_targeted.py
@@ -37,9 +37,10 @@ class TargetedTest(unittest.TestCase):
             {'pattern': '^fs/xfs/.*', 'testcase_name': 'fs/xfs'},
             {'pattern': '^fs/[^/]*[ch]', 'testcase_name': 'fs/xfs'},
         ]
+        actual_value, _ = targeted.get_patterns_by_layout(layout, self.db_dir)
         self.assertListEqual(
             expected_value,
-            targeted.get_patterns_by_layout(layout, self.db_dir)
+            actual_value,
         )
 
     def test_get_src_files(self):
@@ -134,21 +135,27 @@ class TargetedTest(unittest.TestCase):
 
     def test_get_test_cases(self):
         """Check getting test cases according to sources given"""
+        testcases = targeted.get_test_cases([], self.db_dir)
+
         self.assertSequenceEqual(
-            set({'fs/xfs', 'default/ltplite', 'fs/ext4'}),
-            targeted.get_test_cases([], self.db_dir)
+            sorted(['fs/xfs', 'default/ltplite', 'fs/ext4']),
+            sorted([t.testname for t in testcases])
         )
+
         src_files = {
             'fs/xfs/xfs_log.c',
         }
+        testcases = targeted.get_test_cases(src_files, self.db_dir)
         self.assertSequenceEqual(
-            set({'fs/xfs', 'default/ltplite'}),
-            targeted.get_test_cases(src_files, self.db_dir)
+            sorted(['fs/xfs', 'default/ltplite']),
+            sorted([t.testname for t in testcases])
         )
+
         src_files.add('fs/ext4/ext4.h')
+        testcases = targeted.get_test_cases(src_files, self.db_dir)
         self.assertSequenceEqual(
-            set({'fs/xfs', 'default/ltplite', 'fs/ext4'}),
-            targeted.get_test_cases(src_files, self.db_dir)
+            sorted(['fs/xfs', 'default/ltplite', 'fs/ext4']),
+            sorted([t.testname for t in testcases])
         )
 
     def test_get_all_test_cases(self):
@@ -177,15 +184,15 @@ class TargetedTest(unittest.TestCase):
     def test_get_tasks(self):
         """Check tasks template paths are returned by test name"""
         self.assertSequenceEqual(
-            {'fs/xml/xfstests-ext4-4k.xml'},
+            ['fs/xml/xfstests-ext4-4k.xml'],
             targeted.get_tasks(['fs/ext4'], self.db_dir)
         )
         self.assertSequenceEqual(
-            {'default/xml/ltplite.xml', 'fs/xml/xfstests-ext4-4k.xml'},
+            ['fs/xml/xfstests-ext4-4k.xml', 'default/xml/ltplite.xml'],
             targeted.get_tasks(['fs/ext4', 'default/ltplite'], self.db_dir)
         )
         self.assertSequenceEqual(
-            {},
+            [],
             targeted.get_tasks([], self.db_dir)
         )
 
@@ -210,3 +217,7 @@ class TargetedTest(unittest.TestCase):
             {},
             targeted.get_partitions(['fs/ext4'], self.db_dir)
         )
+
+    def test_testcase_class(self):
+        """ Ensure that TestCase returns str when expected."""
+        self.assertEqual(targeted.TestCase('test', None).__repr__(), 'test')

--- a/tox.ini
+++ b/tox.ini
@@ -30,4 +30,5 @@ whitelist_externals = pylint
 commands =
     # Disable R0801 in pylint that checks for duplicate content in multiple
     # files. See https://github.com/PyCQA/pylint/issues/214 for details.
-    pylint -d R0801 --ignored-classes=responses kpet tests
+    # Disable E0012 because of python2/3 pylint incompatibility.
+    pylint -d E0012 -d R0801 --ignored-classes=responses kpet tests


### PR DESCRIPTION
The idea of this patch is this: test is either finished onboarding and
is being added to resulting Beaker XML normally, or it has
enabled|disabled soaking.

If the test soaking is enabled, skt gathers aggregate results of that
test's runcount into redis.
If the test soaking is disabled, we are not gathering any data, but we
know we may want to start (again).

Normal (onboarded tests) should not be affected in any way.

This patch modifies test_targeted and other files to insert

soaking="{val}"

into those test <task /> elements that are enabled for soaking.

A test that has soaking enabled or disabled (isn't onboarded yet) has:

    "soaking": 1
or

    "soaking": 0

If the test doesn't have that, then it's a test that was already
onboarded.
A test that was already onboarded shouldn't be moved to "soaking",
unless it has been failing in some serious way and its maintainer has
failed to care enough to update it.

V2:
* flake8 and pylint fixes
* some superficial test coverage
V3:
* more trivial fixes
V4:
* remove runcount from kpet-db