### PR TITLE
Fix warning in Travis

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -18,6 +18,7 @@ commands =
 passenv = CI TRAVIS TRAVIS_*
 basepython =
     python2.7
+whitelist_externals = flake8
 commands =
     flake8 --show-source .
 
@@ -25,6 +26,7 @@ commands =
 passenv = CI TRAVIS TRAVIS_*
 basepython =
     python2.7
+whitelist_externals = pylint
 commands =
     # Disable R0801 in pylint that checks for duplicate content in multiple
     # files. See https://github.com/PyCQA/pylint/issues/214 for details.


### PR DESCRIPTION
I make PR to resolve warning in travis.
```
flake8 runtests: commands[0] | flake8 --show-source .
WARNING: test command found but not installed in testenv
```