### PR TITLE
Add new param TEST_CASES_KICKSTART on jinja templates

### DIFF
--- a/kpet/run.py
+++ b/kpet/run.py
@@ -67,6 +67,9 @@ def generate(template, template_params, patches, dbdir, output):
     template_params['TEST_CASES_PARTITIONS'] = sorted(
         targeted.get_property('partitions', test_names, dbdir)
     )
+    template_params['TEST_CASES_KICKSTART'] = sorted(
+        targeted.get_property('kickstart', test_names, dbdir)
+    )
     content = template.render(template_params)
     if not output:
         print(content)

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -59,19 +59,13 @@ def generate(template, template_params, patches, dbdir, output):
     """
     test_names = get_test_cases(patches, dbdir)
     template_params['TEST_CASES'] = sorted(
-        targeted.get_tasks(test_names, dbdir)
+        targeted.get_property('tasks', test_names, dbdir, required=True)
     )
     template_params['TEST_CASES_HOST_REQUIRES'] = sorted(
-        targeted.get_host_requires(
-            test_names,
-            dbdir
-        )
+        targeted.get_property('hostRequires', test_names, dbdir)
     )
     template_params['TEST_CASES_PARTITIONS'] = sorted(
-        targeted.get_partitions(
-            test_names,
-            dbdir
-        )
+        targeted.get_property('partitions', test_names, dbdir)
     )
     content = template.render(template_params)
     if not output:

--- a/kpet/targeted.py
+++ b/kpet/targeted.py
@@ -167,55 +167,27 @@ def get_all_test_cases(dbdir):
             yield testcase
 
 
-def get_tasks(test_names, dbdir):
+def get_property(property_name, test_names, dbdir, required=False):
     """
-    Get the corresponding "task" template path for every test name passed.
+    Get the property for every test name passed.
     Args:
-        test_names: List of test names
-        dbdir:      Path to the kpet-db
+        property_name: Property name e.g. hostRequires, tasks, partitions, etc
+        test_names:    List of test names
+        dbdir:         Path to the kpet-db
+        required:      True if the property is mandatory, otherwise False
+    Raises:
+        KeyError:      When the property is not found and it is required.
     Returns:
-        A set of paths to "task" template files.
+        A set of the property values.
     """
     result = set()
     for testcase in get_all_test_cases(dbdir):
         if testcase['name'] in test_names:
-            result.add(testcase['tasks'])
-    return result
-
-
-def get_host_requires(test_names, dbdir):
-    """
-    Get the corresponding "hostRequires" template path for every test name
-    passed.
-    Args:
-        test_names: List of test names
-        dbdir:      Path to the kpet-db
-    Returns:
-        A set of paths to "hostRequires" template files.
-    """
-    result = set()
-    for testcase in get_all_test_cases(dbdir):
-        if testcase['name'] in test_names:
-            host_requires = testcase.get('hostRequires', None)
-            if host_requires:
-                result.add(host_requires)
-    return result
-
-
-def get_partitions(test_names, dbdir):
-    """
-    Get the corresponding "partitions" template path for every test name
-    passed.
-    Args:
-        test_names: List of test names
-        dbdir:      Path to the kpet-db
-    Returns:
-        A set of paths to "partitions" template files.
-    """
-    result = set()
-    for testcase in get_all_test_cases(dbdir):
-        if testcase['name'] in test_names:
-            partitions = testcase.get('partitions', None)
-            if partitions:
-                result.add(partitions)
+            try:
+                property_value = testcase[property_name]
+            except KeyError:
+                if required:
+                    raise
+                continue
+            result.add(property_value)
     return result

--- a/tests/test_targeted.py
+++ b/tests/test_targeted.py
@@ -174,39 +174,28 @@ class TargetedTest(unittest.TestCase):
             list(targeted.get_all_test_cases(self.db_dir))
         )
 
-    def test_get_tasks(self):
-        """Check tasks template paths are returned by test name"""
+    def test_get_property(self):
+        """Check properties are returned by test name"""
         self.assertSequenceEqual(
             {'fs/xml/xfstests-ext4-4k.xml'},
-            targeted.get_tasks(['fs/ext4'], self.db_dir)
+            targeted.get_property('tasks', ['fs/ext4'], self.db_dir)
         )
         self.assertSequenceEqual(
             {'default/xml/ltplite.xml', 'fs/xml/xfstests-ext4-4k.xml'},
-            targeted.get_tasks(['fs/ext4', 'default/ltplite'], self.db_dir)
+            targeted.get_property('tasks', ['fs/ext4', 'default/ltplite'],
+                                  self.db_dir)
         )
-        self.assertSequenceEqual(
-            {},
-            targeted.get_tasks([], self.db_dir)
-        )
-
-    def test_get_host_requires(self):
-        """Check host requires template paths are returned by test name"""
-        self.assertSequenceEqual(
-            {'fs/xml/hostrequires.xml'},
-            targeted.get_host_requires(['fs/ext4'], self.db_dir)
-        )
-        self.assertSequenceEqual(
-            {},
-            targeted.get_host_requires(['fs/xfs'], self.db_dir)
-        )
-
-    def test_get_partitions(self):
-        """Check partitions template paths are returned by test name"""
         self.assertSequenceEqual(
             {'fs/xml/partitions.xml'},
-            targeted.get_partitions(['fs/xfs'], self.db_dir)
+            targeted.get_property('partitions', ['fs/xfs'], self.db_dir)
         )
         self.assertSequenceEqual(
             {},
-            targeted.get_partitions(['fs/ext4'], self.db_dir)
+            targeted.get_property('tasks', [], self.db_dir)
         )
+        self.assertSequenceEqual(
+            {},
+            targeted.get_property('unknown', ['fs/xfs'], self.db_dir)
+        )
+        self.assertRaises(KeyError, targeted.get_property, 'unknown',
+                          ['fs/xfs'], self.db_dir, required=True)


### PR DESCRIPTION
 It allows set a kickstart section by test suite e.g.

```diff
+      <kickstart>
+        {% block kickstart %}
+        {% for test_case_kickstart in TEST_CASES_KICKSTART %}
+          {% include test_case_kickstart %}
+        {% endfor %}
+        {% endblock kickstart %}
+      </kickstart>
```
Also I did a small refactor to remove repeated code, please review it by commit.