### PR TITLE
Add Patchwork cookie option

### DIFF
--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -63,6 +63,11 @@ def build_run_command(cmds_parser, common_parser):
         help='Path where will be saved the xml, default is stdout'
     )
     generate_parser.add_argument(
+        '--pw-cookie',
+        default=None,
+        help='Patchwork session cookie in case a login is required'
+    )
+    generate_parser.add_argument(
         '-t',
         '--tree',
         required=True,
@@ -108,6 +113,11 @@ def build_run_command(cmds_parser, common_parser):
         nargs='*',
         default=[],
         help='List of patches URLs/paths'
+    )
+    print_test_cases_parser.add_argument(
+        '--pw-cookie',
+        default=None,
+        help='Patchwork session cookie in case a login is required'
     )
 
 

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -66,6 +66,7 @@ class RunTest(unittest.TestCase):
         mock_args.arch = 'arch'
         mock_args.db = 'db'
         mock_args.output = None
+        mock_args.pw_cookie = None
         mock_args.description = 'description'
         mock_args.mboxes = []
         with mock.patch('kpet.run.generate') as mock_generate:
@@ -84,6 +85,7 @@ class RunTest(unittest.TestCase):
                     },
                     [],
                     'db',
+                    None,
                     None
                 )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -49,7 +49,8 @@ class UtilsTest(unittest.TestCase):
                 ['http://mypatch.org', '/localfile'],
                 tmpdir
             )
-            mock_request_get.assert_called_with('http://mypatch.org')
+            mock_request_get.assert_called_with('http://mypatch.org',
+                                                cookies=None)
             with open(patches[0]) as file_handler:
                 file_content = file_handler.read()
             self.assertEqual('some content', file_content)


### PR DESCRIPTION
Mimics skt#f6791b75b17e. Nothing changes for normal workflows, just
people dealing with protected Patchwork instances can now run kpet.

Signed-off-by: Veronika Kabatova <vkabatov@redhat.com>