### PR TITLE
move waiving attribute to json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ kpet.egg-info
 .tox/
 .coverage
 .eggs/
+.idea/

--- a/tests/test_kpet.py
+++ b/tests/test_kpet.py
@@ -61,12 +61,14 @@ class ArgumentParserTest(unittest.TestCase):
         self.assertEqual('bar', args.kernel)
         self.assertListEqual(['mbox1', 'mbox2'], args.mboxes)
 
-    def test_exec_command(self):
+    @mock.patch('logging.error')
+    def test_exec_command(self, mock_logging):
         """
         Check the success case, command in question raises an exception,
         that SystemExit is ignored and when a command is not implemented prints
         `Not implemented yet` on stderr
         """
+        # pylint: disable=unused-argument
         mock_command = mock.Mock()
         commands = {
             'foobar': [mock_command, 'foo', 'bar'],

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -113,3 +113,14 @@ class RunTest(unittest.TestCase):
         mock_get_test_cases.return_value = ['default/ltplite', 'fs/xfs']
         test_cases = run.get_test_cases("", "")
         self.assertEqual(mock_get_test_cases.return_value, test_cases)
+
+    def test_get_waived_inner(self):
+        """ Ensure that get_waived_inner() works."""
+        tasks = ['test', 'jest']
+        is_waived = [1, 0]
+
+        result = run.get_waived_inner('test', tasks, is_waived)
+        self.assertEqual(result, '<param name="_WAIVED" value="True"/>')
+
+        result = run.get_waived_inner('jest', tasks, is_waived)
+        self.assertEqual(result, '<param name="_WAIVED" value="False"/>')

--- a/tests/test_targeted.py
+++ b/tests/test_targeted.py
@@ -171,30 +171,31 @@ class TargetedTest(unittest.TestCase):
         ]
         self.assertListEqual(
             expected_value,
-            list(targeted.get_all_test_cases(self.db_dir))
+            [testcase for testcase, _ in
+             list(targeted.get_all_test_cases(self.db_dir))]
         )
 
     def test_get_property(self):
         """Check properties are returned by test name"""
         self.assertSequenceEqual(
-            {'fs/xml/xfstests-ext4-4k.xml'},
+            ['fs/xml/xfstests-ext4-4k.xml'],
             targeted.get_property('tasks', ['fs/ext4'], self.db_dir)
         )
         self.assertSequenceEqual(
-            {'default/xml/ltplite.xml', 'fs/xml/xfstests-ext4-4k.xml'},
+            ['default/xml/ltplite.xml', 'fs/xml/xfstests-ext4-4k.xml'],
             targeted.get_property('tasks', ['fs/ext4', 'default/ltplite'],
                                   self.db_dir)
         )
         self.assertSequenceEqual(
-            {'fs/xml/partitions.xml'},
+            ['fs/xml/partitions.xml'],
             targeted.get_property('partitions', ['fs/xfs'], self.db_dir)
         )
         self.assertSequenceEqual(
-            {},
+            [],
             targeted.get_property('tasks', [], self.db_dir)
         )
         self.assertSequenceEqual(
-            {},
+            [],
             targeted.get_property('unknown', ['fs/xfs'], self.db_dir)
         )
         self.assertRaises(KeyError, targeted.get_property, 'unknown',


### PR DESCRIPTION
This patch moves the governing waive-enable to json.
Each waive-enable is now governed by "waived": 1 (or 0)
in each patterns.json file.

The code modifies generated XML by using jinja. Parameter like

<param name="_WAIVED" value="VALUE"/>

where VALUE is True or False

is inserted into those test <task /> elements that are waived.
The task has to have something like

<params >
{{get_waived(test_case)}}
<params/>

that calls the function to get the waive value.

The waived tests are put as last.
Otherwise the order of tests is not affected.

No other functional changes intended.

Signed-off-by: Jakub Racek <jracek@redhat.com>