### PR TITLE
DB backend rewrite, part 1

### DIFF
--- a/kpet/data.py
+++ b/kpet/data.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""KPET data"""
+
+import os
+from kpet.schema import Invalid, Int, Struct, StrictStruct, \
+    List, Dict, String, Regex, ScopedYAMLFile, YAMLFile, Class
+
+# pylint: disable=raising-format-tuple,useless-object-inheritance
+
+
+class Object(object):   # pylint: disable=too-few-public-methods
+    """An abstract data object"""
+    def __init__(self, schema, data):
+        """
+        Initialize an abstract data object with a schema validating and
+        resolving a supplied data.
+
+        Args:
+            schema: The schema of the data, must recognize to a Struct.
+            data:   The object data to be validated against and resolved with
+                    the schema.
+        """
+        # Validate and resolve the data
+        try:
+            data = schema.resolve(data)
+        except Invalid:
+            raise Invalid("Invalid {} data", type(self).__name__)
+
+        # Recognize the schema
+        schema = schema.recognize()
+        assert isinstance(schema, Struct)
+        try:
+            schema.validate(data)
+        except Invalid as exc:
+            raise Exception("Resolved data is invalid:\n{}".format(exc))
+
+        # Assign members
+        for member_name in schema.required.keys():
+            setattr(self, member_name, data[member_name])
+        for member_name in schema.optional.keys():
+            if member_name in data:
+                setattr(self, member_name, data[member_name])
+
+
+class TestSuite(Object):    # pylint: disable=too-few-public-methods
+    """Test suite"""
+    def __init__(self, data):
+        super(TestSuite, self).__init__(
+            StrictStruct(
+                description=String(),
+                version=String(),
+                patterns=List(StrictStruct(pattern=Regex(),
+                                           testcase_name=String())),
+                cases=List(
+                    Struct(
+                        required=dict(
+                            name=String(),
+                            tasks=String()
+                        ),
+                        optional=dict(
+                            hostRequires=String(),
+                            partitions=String(),
+                            kickstart=String()
+                        )
+                    )
+                )
+            ),
+            data
+        )
+
+
+class Base(Object):     # pylint: disable=too-few-public-methods
+    """Database"""
+
+    @staticmethod
+    def is_dir_valid(dir_path):
+        """
+        Check if a directory is a valid database.
+
+        Args:
+            dir_path:   Path to the directory to check.
+
+        Returns:
+            True if the directory is a valid database directory,
+            False otherwise.
+        """
+        return os.path.isfile(dir_path + "/layout/layout.json")
+
+    def __init__(self, dir_path):
+        """
+        Initialize a database object.
+        """
+        super(Base, self).__init__(
+            ScopedYAMLFile(
+                StrictStruct(
+                    schema=StrictStruct(version=Int()),
+                    testsuites=Dict(YAMLFile(Class(TestSuite)))
+                )
+            ),
+            dir_path + "/layout/layout.json")
+        self.dir_path = dir_path

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -32,7 +32,7 @@ def get_test_cases(patches, database, pw_cookie=None):
     try:
         patches = utils.patch2localfile(patches, tmpdir, pw_cookie)
         src_files = targeted.get_src_files(patches)
-        return sorted(targeted.get_test_cases(src_files, database.dir_path))
+        return sorted(targeted.get_test_cases(src_files, database))
     finally:
         shutil.rmtree(tmpdir)
 
@@ -67,17 +67,17 @@ def generate(template, template_params, patches, database, output,
     """
     test_names = get_test_cases(patches, database, pw_cookie)
     template_params['TEST_CASES'] = sorted(
-        targeted.get_property('tasks', test_names, database.dir_path,
+        targeted.get_property('tasks', test_names, database,
                               required=True)
     )
     template_params['TEST_CASES_HOST_REQUIRES'] = sorted(
-        targeted.get_property('hostRequires', test_names, database.dir_path)
+        targeted.get_property('hostRequires', test_names, database)
     )
     template_params['TEST_CASES_PARTITIONS'] = sorted(
-        targeted.get_property('partitions', test_names, database.dir_path)
+        targeted.get_property('partitions', test_names, database)
     )
     template_params['TEST_CASES_KICKSTART'] = sorted(
-        targeted.get_property('kickstart', test_names, database.dir_path)
+        targeted.get_property('kickstart', test_names, database)
     )
     content = template.render(template_params)
     if not output:

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -51,7 +51,7 @@ def print_test_cases(patches, dbdir, pw_cookie=None):
 
 
 # pylint: disable=too-many-arguments
-def generate(template, template_params, patches, dbdir, output,
+def generate(template, template_params, patches, database, output,
              pw_cookie=None):
     """
     Generate an xml output compatible with beaker.
@@ -60,23 +60,24 @@ def generate(template, template_params, patches, dbdir, output,
         template_params: A dictionary with template parameters such as arch,
                          whiteboard description, etc.
         patches:         List of patches, can be local files or remote urls
-        dbdir:           Path to the kpet-db
+        database:        Database instance
         output:          Output file where beaker xml will be rendered
         pw_cookie:       Session cookie to Patchwork instance if login is
                          required, None otherwise
     """
-    test_names = get_test_cases(patches, dbdir, pw_cookie)
+    test_names = get_test_cases(patches, database.dir_path, pw_cookie)
     template_params['TEST_CASES'] = sorted(
-        targeted.get_property('tasks', test_names, dbdir, required=True)
+        targeted.get_property('tasks', test_names, database.dir_path,
+                              required=True)
     )
     template_params['TEST_CASES_HOST_REQUIRES'] = sorted(
-        targeted.get_property('hostRequires', test_names, dbdir)
+        targeted.get_property('hostRequires', test_names, database.dir_path)
     )
     template_params['TEST_CASES_PARTITIONS'] = sorted(
-        targeted.get_property('partitions', test_names, dbdir)
+        targeted.get_property('partitions', test_names, database.dir_path)
     )
     template_params['TEST_CASES_KICKSTART'] = sorted(
-        targeted.get_property('kickstart', test_names, dbdir)
+        targeted.get_property('kickstart', test_names, database.dir_path)
     )
     content = template.render(template_params)
     if not output:
@@ -90,6 +91,7 @@ def main(args):
     """Main function for the `run` command"""
     if not data.Base.is_dir_valid(args.db):
         raise Exception("\"{}\" is not a database directory".format(args.db))
+    database = data.Base(args.db)
     if args.action == 'generate':
         template = utils.get_jinja_template(args.tree, args.db)
         template_params = {
@@ -99,8 +101,8 @@ def main(args):
             'TREE': args.tree,
             'getenv': os.getenv,
         }
-        generate(template, template_params, args.mboxes, args.db, args.output,
-                 args.pw_cookie)
+        generate(template, template_params, args.mboxes, database,
+                 args.output, args.pw_cookie)
     elif args.action == 'print-test-cases':
         print_test_cases(args.patches, args.db, args.pw_cookie)
     else:

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -67,8 +67,7 @@ def generate(template, template_params, patches, database, output,
     """
     test_names = get_test_cases(patches, database, pw_cookie)
     template_params['TEST_CASES'] = sorted(
-        targeted.get_property('tasks', test_names, database,
-                              required=True)
+        targeted.get_property('tasks', test_names, database)
     )
     template_params['TEST_CASES_HOST_REQUIRES'] = sorted(
         targeted.get_property('hostRequires', test_names, database)

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -16,7 +16,7 @@ from __future__ import print_function
 import tempfile
 import shutil
 import os
-from kpet import utils, targeted
+from kpet import utils, targeted, data
 
 
 def get_test_cases(patches, dbdir, pw_cookie=None):
@@ -88,6 +88,8 @@ def generate(template, template_params, patches, dbdir, output,
 
 def main(args):
     """Main function for the `run` command"""
+    if not data.Base.is_dir_valid(args.db):
+        raise Exception("\"{}\" is not a database directory".format(args.db))
     if args.action == 'generate':
         template = utils.get_jinja_template(args.tree, args.db)
         template_params = {

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -19,12 +19,12 @@ import os
 from kpet import utils, targeted, data
 
 
-def get_test_cases(patches, dbdir, pw_cookie=None):
+def get_test_cases(patches, database, pw_cookie=None):
     """
     Return test cases by querying layout according list of patch files.
     Args:
         patches:   List of patches, they can be local files or remote urls
-        dbdir:     Path to the kpet-db
+        database:  Database instance
         pw_cookie: Session cookie to Patchwork instance if login is required,
                    None otherwise
     """
@@ -32,21 +32,21 @@ def get_test_cases(patches, dbdir, pw_cookie=None):
     try:
         patches = utils.patch2localfile(patches, tmpdir, pw_cookie)
         src_files = targeted.get_src_files(patches)
-        return sorted(targeted.get_test_cases(src_files, dbdir))
+        return sorted(targeted.get_test_cases(src_files, database.dir_path))
     finally:
         shutil.rmtree(tmpdir)
 
 
-def print_test_cases(patches, dbdir, pw_cookie=None):
+def print_test_cases(patches, database, pw_cookie=None):
     """
     Print test cases by querying layout according list of patch files.
     Args:
         patches:   List of patches, they can be local files or remote urls
-        dbdir:     Path to the kpet-db
+        database:  Database instance
         pw_cookie: Session cookie to Patchwork instance if login is required,
                    None otherwise
     """
-    for test_case in get_test_cases(patches, dbdir, pw_cookie):
+    for test_case in get_test_cases(patches, database, pw_cookie):
         print(test_case)
 
 
@@ -65,7 +65,7 @@ def generate(template, template_params, patches, database, output,
         pw_cookie:       Session cookie to Patchwork instance if login is
                          required, None otherwise
     """
-    test_names = get_test_cases(patches, database.dir_path, pw_cookie)
+    test_names = get_test_cases(patches, database, pw_cookie)
     template_params['TEST_CASES'] = sorted(
         targeted.get_property('tasks', test_names, database.dir_path,
                               required=True)
@@ -104,6 +104,6 @@ def main(args):
         generate(template, template_params, args.mboxes, database,
                  args.output, args.pw_cookie)
     elif args.action == 'print-test-cases':
-        print_test_cases(args.patches, args.db, args.pw_cookie)
+        print_test_cases(args.patches, database, args.pw_cookie)
     else:
         utils.raise_action_not_found(args.action, args.command)

--- a/kpet/schema.py
+++ b/kpet/schema.py
@@ -1,0 +1,375 @@
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""Database schema"""
+
+import re
+import os
+import yaml
+
+# pylint: disable=raising-format-tuple,useless-object-inheritance
+
+
+# The type returned by re.compile(). Different between Python 2 and 3
+_RE = type(re.compile(""))
+
+
+def _get_re_error_type():
+    """
+    Get the type of the exception produced when an invalid regular expression
+    is compiled.
+
+    Returns:
+        The "invalid regular expression" exception type.
+    Raises:
+        Exception   when the type cannot be discovered.
+    """
+    try:
+        re.compile("(")
+    except Exception as exc:    # pylint: disable=broad-except
+        return type(exc)
+    raise Exception("\"Invalid regex\" exception type not found")
+
+
+# The exception type produced by re.compile() on invalid regex.
+# Different between Python 2 and 3, and unavailable directly in Python 2
+_ReError = _get_re_error_type()
+
+
+class Invalid(Exception):
+    """Invalid data exception"""
+
+    def __init__(self, fmt, *args):
+        super(Invalid, self).__init__(fmt.format(*args))
+
+    def __str__(self):
+        # pylint: disable=no-member
+        return super(Invalid, self).__str__() + \
+               (":\n" + str(self.__context__)
+                if hasattr(self, "__context__") and self.__context__ else "")
+
+
+class Node(object):
+    """
+    Abstract node schema validating the data to be an instance of specified
+    type and resolving to the same.
+    """
+    def __init__(self, data_type):
+        """
+        Initialize a node schema.
+
+        Args:
+            data_type:  The type the data should be instance of.
+        """
+        self.data_type = data_type
+
+    def validate(self, data):
+        """
+        Validate data according to the schema.
+
+        Args:
+            The data to validate.
+
+        Raises:
+            Invalid:    The data didn't match the schema.
+        """
+        if not isinstance(data, self.data_type):
+            raise Invalid("Invalid type: {}, expecting {}",
+                          type(data).__name__, self.data_type.__name__)
+
+    def recognize(self):
+        """
+        Recognize the schema - return the schema that resolved data would
+        have.
+
+        Returns:
+            The schema the resolved data would have.
+        """
+        return self
+
+    def resolve(self, data):
+        """
+        Resolve (validate and massage) data according to the schema.
+
+        Args:
+            data:   The data to resolve.
+
+        Returns:
+            The resolved data. Will match the recognized schema.
+        """
+        self.validate(data)
+        return data
+
+
+class String(Node):
+    """String schema"""
+    def __init__(self):
+        super(String, self).__init__(str)
+
+
+class Int(Node):
+    """Integer number schema"""
+    def __init__(self):
+        super(Int, self).__init__(int)
+
+
+class Float(Node):
+    """Floating-point number schema"""
+    def __init__(self):
+        super(Float, self).__init__(float)
+
+
+class Boolean(Node):
+    """Boolean schema"""
+    def __init__(self):
+        super(Boolean, self).__init__(bool)
+
+
+class Regex(String):
+    """
+    Regular expression string schema.
+    """
+    def validate(self, data):
+        super(Regex, self).validate(data)
+        try:
+            re.compile(data)
+        except _ReError:
+            raise Invalid("Invalid regular expression")
+
+    def recognize(self):
+        return Node(_RE)
+
+    def resolve(self, data):
+        self.validate(data)
+        return re.compile(data)
+
+
+class RelativeFilePath(String):
+    """
+    Relative file path schema, resolved to the same schema and absolute file
+    path.
+    """
+    def resolve(self, data):
+        self.validate(data)
+        return os.path.realpath(data)
+
+
+class YAMLFile(String):
+    """
+    YAML file path schema, resolved to the file contents according to
+    specified schema.
+    """
+    def __init__(self, contents_schema):
+        assert isinstance(contents_schema, Node)
+        super(YAMLFile, self).__init__()
+        self.contents_schema = contents_schema
+
+    def recognize(self):
+        return self.contents_schema.recognize()
+
+    def resolve(self, data):
+        self.validate(data)
+        file_path = os.path.realpath(data)
+
+        # Load the data
+        with open(file_path, "r") as resolved_data_file:
+            resolved_data = yaml.load(resolved_data_file)
+
+        # Resolve loaded data
+        try:
+            return self.contents_schema.resolve(resolved_data)
+        except Invalid:
+            raise Invalid("Invalid contents of {}", file_path)
+
+
+class ScopedYAMLFile(YAMLFile):
+    """
+    YAML file path schema, resolved to file contents according to specified
+    schema, changes the current directory to the file's directory when
+    resolving the contents.
+    """
+    def resolve(self, data):
+        self.validate(data)
+        file_path = os.path.realpath(data)
+        dir_path = os.path.dirname(file_path)
+
+        # Load the data
+        with open(file_path, "r") as resolved_data_file:
+            resolved_data = yaml.load(resolved_data_file)
+
+        # Validate and resolve loaded data
+        orig_dir_path = os.getcwd()
+        os.chdir(dir_path)
+        try:
+            return self.contents_schema.resolve(resolved_data)
+        except Invalid:
+            raise Invalid("Invalid contents of {}", file_path)
+        finally:
+            os.chdir(orig_dir_path)
+
+
+class List(Node):
+    """
+    List schema, with every element matching a single specified schema.
+    """
+    def __init__(self, element_schema):
+        assert isinstance(element_schema, Node)
+        super(List, self).__init__(list)
+        self.element_schema = element_schema
+
+    def validate(self, data):
+        super(List, self).validate(data)
+        for index, value in enumerate(data):
+            try:
+                self.element_schema.validate(value)
+            except Invalid:
+                raise Invalid("Invalid value at index {}", index)
+
+    def recognize(self):
+        return List(self.element_schema.recognize())
+
+    def resolve(self, data):
+        self.validate(data)
+        return [self.element_schema.resolve(value) for value in data]
+
+
+class Dict(Node):
+    """
+    Dictionary schema, with string keys and every value matching a single
+    specified schema.
+    """
+    def __init__(self, value_schema):
+        assert isinstance(value_schema, Node)
+        super(Dict, self).__init__(dict)
+        self.value_schema = value_schema
+
+    def validate(self, data):
+        super(Dict, self).validate(data)
+        for key, value in data.items():
+            if not isinstance(key, str):
+                raise Invalid("Key \"{}\" is {}, expecting a string",
+                              key, type(key).__name__)
+            try:
+                self.value_schema.validate(value)
+            except Invalid:
+                raise Invalid("Invalid value with key \"{}\"", key)
+
+    def recognize(self):
+        return Dict(self.value_schema.recognize())
+
+    def resolve(self, data):
+        self.validate(data)
+        resolved_data = {}
+        for key, value in data.items():
+            resolved_data[key] = self.value_schema.resolve(value)
+        return resolved_data
+
+
+class Struct(Dict):
+    """
+    Dictionary schema, with string keys and each key having values with its
+    own schema.
+    """
+    def __init__(self, required=None, optional=None):
+        """
+        Initialize a struct schema.
+
+        Args:
+            required:   A dictionary of keys required to be present in the
+                        dictionary, mapped to their value schemas.
+            optional:   A dictionary of keys that can be present in the
+                        dictionary, but are not required, mapped to their
+                        value schemas.
+        """
+        assert required is None or isinstance(required, dict)
+        assert optional is None or isinstance(optional, dict)
+        super(Struct, self).__init__(Node(object))
+        if required is None:
+            required = {}
+        if optional is None:
+            optional = {}
+        for key, value in required.items():
+            assert isinstance(key, str)
+            assert isinstance(value, Node)
+        for key, value in optional.items():
+            assert isinstance(key, str)
+            assert isinstance(value, Node)
+        self.required = required
+        self.optional = optional
+
+    def validate(self, data):
+        super(Struct, self).validate(data)
+        for name, schema in self.required.items():
+            if name not in data:
+                raise Invalid("Member \"{}\" is missing", name)
+            value = data[name]
+            try:
+                schema.validate(value)
+            except Invalid:
+                raise Invalid("Member \"{}\" is invalid", name)
+        for name, schema in self.optional.items():
+            if name in data:
+                value = data[name]
+                try:
+                    schema.validate(value)
+                except Invalid:
+                    raise Invalid("Member \"{}\" is invalid", name)
+
+    def recognize(self):
+        recognized_required = {}
+        recognized_optional = {}
+
+        for name, schema in self.required.items():
+            recognized_required[name] = schema.recognize()
+        for name, schema in self.optional.items():
+            recognized_optional[name] = schema.recognize()
+
+        return Struct(required=recognized_required,
+                      optional=recognized_optional)
+
+    def resolve(self, data):
+        self.validate(data)
+        resolved_data = {}
+
+        for name, schema in self.required.items():
+            resolved_data[name] = schema.resolve(data[name])
+        for name, schema in self.optional.items():
+            if name in data:
+                resolved_data[name] = schema.resolve(data[name])
+
+        return resolved_data
+
+
+class StrictStruct(Struct):
+    """
+    Struct schema with required keys only.
+    """
+    def __init__(self, **kwargs):
+        super(StrictStruct, self).__init__(required=kwargs)
+
+
+class Class(Node):
+    """
+    Class instance schema, resolves to a class instance with (arbitrary) data
+    as the creation argument.
+    """
+    def __init__(self, instance_type):
+        super(Class, self).__init__(object)
+        self.instance_type = instance_type
+
+    def recognize(self):
+        return Node(object)
+
+    def resolve(self, data):
+        self.validate(data)
+        return self.instance_type(data)

--- a/kpet/targeted.py
+++ b/kpet/targeted.py
@@ -25,21 +25,6 @@ class UnrecognizedPatchPathFormat(Exception):
     """Raised when can't extract source file path from a diff header"""
 
 
-def get_patterns(database):
-    """
-    Retrieve all testcase patterns.
-    Args:
-        database:   Database instance
-    Returns:
-        A list of dictionaries with two fields: "testcase_name" and "pattern"
-        - test case name string and a compiled regex correspondingly.
-    """
-    patterns = []
-    for suite in database.testsuites.values():
-        patterns.extend(suite.patterns)
-    return patterns
-
-
 def __get_src_file_path(diff_header_path):
     """
     Extract source file path from a path from a ---/+++ diff header.
@@ -134,16 +119,16 @@ def get_test_cases(src_files, database):
         All names of test cases applicable to the src_files. It'll return all
         of them if src_files is empty.
     """
-    patterns = get_patterns(database)
-
     testcases = set()
-    for pattern in patterns:
-        if not src_files:
-            testcases.add(pattern['testcase_name'])
-        else:
-            for src_path in src_files:
-                if pattern['pattern'].match(src_path):
-                    testcases.add(pattern['testcase_name'])
+
+    for suite in database.testsuites.values():
+        for pattern in suite.patterns:
+            if not src_files:
+                testcases.add(pattern['testcase_name'])
+            else:
+                for src_path in src_files:
+                    if pattern['pattern'].match(src_path):
+                        testcases.add(pattern['testcase_name'])
 
     return testcases
 

--- a/kpet/targeted.py
+++ b/kpet/targeted.py
@@ -127,18 +127,18 @@ def get_layout(dbdir):
     return obj['testsuites']
 
 
-def get_test_cases(src_files, dbdir):
+def get_test_cases(src_files, database):
     """
     Get test cases by querying layout according to source files.
     Args:
         src_files: List of kernel source files
-        dbdir:  Path to the kpet-db
+        database:  Database instance
     Returns:
         All test cases applicable to the src_files. It'll return all of them
         if src_files is empty.
     """
-    layout = get_layout(dbdir)
-    patterns = get_patterns_by_layout(layout, dbdir)
+    layout = get_layout(database.dir_path)
+    patterns = get_patterns_by_layout(layout, database.dir_path)
 
     test_cases = set()
     for pattern_item in patterns:
@@ -151,29 +151,29 @@ def get_test_cases(src_files, dbdir):
     return test_cases
 
 
-def get_all_test_cases(dbdir):
+def get_all_test_cases(database):
     """
     Get a generator iterating over all testcases defined in the database.
     Args:
-        dbdir: Path to the kpet-db
+        database:   Database instance
     Returns:
         A generator iterating over all test cases.
     """
-    for _, path in get_layout(dbdir).items():
-        pattern_file = os.path.join(dbdir, 'layout', path)
+    for _, path in get_layout(database.dir_path).items():
+        pattern_file = os.path.join(database.dir_path, 'layout', path)
         with open(pattern_file) as file_handler:
             pattern = json.load(file_handler)
         for testcase in pattern['cases']:
             yield testcase
 
 
-def get_property(property_name, test_names, dbdir, required=False):
+def get_property(property_name, test_names, database, required=False):
     """
     Get the property for every test name passed.
     Args:
         property_name: Property name e.g. hostRequires, tasks, partitions, etc
         test_names:    List of test names
-        dbdir:         Path to the kpet-db
+        database:      Database instance
         required:      True if the property is mandatory, otherwise False
     Raises:
         KeyError:      When the property is not found and it is required.
@@ -181,7 +181,7 @@ def get_property(property_name, test_names, dbdir, required=False):
         A set of the property values.
     """
     result = set()
-    for testcase in get_all_test_cases(dbdir):
+    for testcase in get_all_test_cases(database):
         if testcase['name'] in test_names:
             try:
                 property_value = testcase[property_name]

--- a/kpet/targeted.py
+++ b/kpet/targeted.py
@@ -116,30 +116,22 @@ def get_test_cases(src_files, database):
     return testcases
 
 
-def get_property(property_name, test_names, database, required=False):
+def get_property(property_name, test_names, database):
     """
     Get the property for every test name passed.
     Args:
         property_name: Property name e.g. hostRequires, tasks, partitions, etc
         test_names:    List of test names
         database:      Database instance
-        required:      True if the property is mandatory, otherwise False
-    Raises:
-        KeyError:      When the property is not found and it is required.
     Returns:
         A set of the property values.
     """
     result = set()
-
     for testsuite in database.testsuites.values():
         for testcase in testsuite.cases:
             if testcase['name'] in test_names:
-                try:
+                if property_name in testcase:
                     property_value = testcase[property_name]
-                except KeyError:
-                    if required:
-                        raise
-                    continue
-                if property_value is not None:
-                    result.add(property_value)
+                    if property_value is not None:
+                        result.add(property_value)
     return result

--- a/kpet/targeted.py
+++ b/kpet/targeted.py
@@ -32,7 +32,8 @@ def get_patterns_by_layout(layout, dbdir):
         layout: The content of the layout.json file of the corresponding db
         dbdir:  Path to the kpet-db
     Returns:
-        List of tuple (regex, testcase-name)
+        A list of dictionaries with two fields: "testcase_name" and "pattern"
+        - test case name string and a regex string correspondingly.
     """
     patterns = []
     for _, path in layout.items():

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,6 +27,7 @@ python_requires = >= 2.7, != 3.0.*, != 3.1.*, != 3.2.*
 test_suite = tests
 install_requires = requests
                    Jinja2
+                   PyYAML
 tests_require = mock
 
 [options.extras_require]

--- a/tests/test_kpet.py
+++ b/tests/test_kpet.py
@@ -102,8 +102,7 @@ class ArgumentParserTest(unittest.TestCase):
 
     def test_main(self):
         """
-        Check --db is required and also run generate command executes
-        successfully
+        Check run generate command executes successfully
         """
         dbdir = os.path.join(os.path.dirname(__file__), 'assets')
         args = ['--db', dbdir, 'run', 'generate', '-t', 'rhel7', '-k',

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -92,25 +92,3 @@ class RunTest(unittest.TestCase):
 
         mock_args.action = 'action-not-found'
         self.assertRaises(exceptions.ActionNotFound, run.main, mock_args)
-
-    @mock.patch('kpet.targeted.get_test_cases')
-    def test_print_test_cases(self, mock_get_test_cases):
-        """
-        Check print_test_cases prints the suggested test cases.
-        """
-        mock_get_test_cases.return_value = ['default/ltplite', 'fs/xfs']
-        with mock.patch('sys.stdout') as mock_stdout:
-            run.print_test_cases("", "")
-        self.assertEqual('default/ltplite',
-                         mock_stdout.write.call_args_list[0][0][0])
-        self.assertEqual('fs/xfs',
-                         mock_stdout.write.call_args_list[2][0][0])
-
-    @mock.patch('kpet.targeted.get_test_cases')
-    def test_get_test_cases(self, mock_get_test_cases):
-        """
-        Check get_test_cases returns the suggested test cases.
-        """
-        mock_get_test_cases.return_value = ['default/ltplite', 'fs/xfs']
-        test_cases = run.get_test_cases("", "")
-        self.assertEqual(mock_get_test_cases.return_value, test_cases)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -16,7 +16,7 @@ import os
 import tempfile
 import unittest
 import mock
-from kpet import run, utils, exceptions
+from kpet import run, utils, data, exceptions
 
 
 class RunTest(unittest.TestCase):
@@ -33,9 +33,10 @@ class RunTest(unittest.TestCase):
             'ARCH': 'baz',
         }
         dbdir = os.path.join(os.path.dirname(__file__), 'assets')
+        database = data.Base(dbdir)
         template = utils.get_jinja_template('rhel7', dbdir)
         with mock.patch('sys.stdout') as mock_stdout:
-            run.generate(template, template_params, [], dbdir, None)
+            run.generate(template, template_params, [], database, None)
         with open(os.path.join(dbdir, 'rhel7_rendered.xml')) as file_handler:
             content_expected = file_handler.read()
         self.assertEqual(
@@ -44,7 +45,7 @@ class RunTest(unittest.TestCase):
         )
 
         tmpfile = tempfile.mktemp()
-        run.generate(template, template_params, [], dbdir, tmpfile)
+        run.generate(template, template_params, [], database, tmpfile)
         with open(tmpfile) as tmp_handler:
             content = tmp_handler.read()
         self.assertEqual(
@@ -64,7 +65,7 @@ class RunTest(unittest.TestCase):
         mock_args.tree = 'rhel7'
         mock_args.kernel = 'kernel'
         mock_args.arch = 'arch'
-        mock_args.db = 'db'
+        mock_args.db = os.path.join(os.path.dirname(__file__), 'assets')
         mock_args.output = None
         mock_args.pw_cookie = None
         mock_args.description = 'description'
@@ -84,7 +85,7 @@ class RunTest(unittest.TestCase):
                         'getenv': os.getenv,
                     },
                     [],
-                    'db',
+                    mock.ANY,
                     None,
                     None
                 )

--- a/tests/test_targeted.py
+++ b/tests/test_targeted.py
@@ -158,5 +158,3 @@ class TargetedTest(unittest.TestCase):
             {},
             targeted.get_property('unknown', ['fs/xfs'], database)
         )
-        self.assertRaises(KeyError, targeted.get_property, 'unknown',
-                          ['fs/xfs'], database, required=True)

--- a/tests/test_targeted.py
+++ b/tests/test_targeted.py
@@ -16,7 +16,7 @@ import os
 import json
 import tempfile
 import unittest
-from kpet import targeted
+from kpet import targeted, data
 
 
 class TargetedTest(unittest.TestCase):
@@ -134,21 +134,22 @@ class TargetedTest(unittest.TestCase):
 
     def test_get_test_cases(self):
         """Check getting test cases according to sources given"""
+        database = data.Base(self.db_dir)
         self.assertSequenceEqual(
             set({'fs/xfs', 'default/ltplite', 'fs/ext4'}),
-            targeted.get_test_cases([], self.db_dir)
+            targeted.get_test_cases([], database)
         )
         src_files = {
             'fs/xfs/xfs_log.c',
         }
         self.assertSequenceEqual(
             set({'fs/xfs', 'default/ltplite'}),
-            targeted.get_test_cases(src_files, self.db_dir)
+            targeted.get_test_cases(src_files, database)
         )
         src_files.add('fs/ext4/ext4.h')
         self.assertSequenceEqual(
             set({'fs/xfs', 'default/ltplite', 'fs/ext4'}),
-            targeted.get_test_cases(src_files, self.db_dir)
+            targeted.get_test_cases(src_files, database)
         )
 
     def test_get_all_test_cases(self):
@@ -171,31 +172,32 @@ class TargetedTest(unittest.TestCase):
         ]
         self.assertListEqual(
             expected_value,
-            list(targeted.get_all_test_cases(self.db_dir))
+            list(targeted.get_all_test_cases(data.Base(self.db_dir)))
         )
 
     def test_get_property(self):
         """Check properties are returned by test name"""
+        database = data.Base(self.db_dir)
         self.assertSequenceEqual(
             {'fs/xml/xfstests-ext4-4k.xml'},
-            targeted.get_property('tasks', ['fs/ext4'], self.db_dir)
+            targeted.get_property('tasks', ['fs/ext4'], database)
         )
         self.assertSequenceEqual(
             {'default/xml/ltplite.xml', 'fs/xml/xfstests-ext4-4k.xml'},
             targeted.get_property('tasks', ['fs/ext4', 'default/ltplite'],
-                                  self.db_dir)
+                                  database)
         )
         self.assertSequenceEqual(
             {'fs/xml/partitions.xml'},
-            targeted.get_property('partitions', ['fs/xfs'], self.db_dir)
+            targeted.get_property('partitions', ['fs/xfs'], database)
         )
         self.assertSequenceEqual(
             {},
-            targeted.get_property('tasks', [], self.db_dir)
+            targeted.get_property('tasks', [], database)
         )
         self.assertSequenceEqual(
             {},
-            targeted.get_property('unknown', ['fs/xfs'], self.db_dir)
+            targeted.get_property('unknown', ['fs/xfs'], database)
         )
         self.assertRaises(KeyError, targeted.get_property, 'unknown',
-                          ['fs/xfs'], self.db_dir, required=True)
+                          ['fs/xfs'], database, required=True)

--- a/tests/test_targeted.py
+++ b/tests/test_targeted.py
@@ -134,29 +134,6 @@ class TargetedTest(unittest.TestCase):
             targeted.get_test_cases(src_files, database)
         )
 
-    def test_get_all_test_cases(self):
-        """Check all test cases in the database are returned"""
-        expected_value = [
-            {
-                'name': 'default/ltplite',
-                'tasks': 'default/xml/ltplite.xml',
-            },
-            {
-                'name': 'fs/ext4',
-                'tasks': 'fs/xml/xfstests-ext4-4k.xml',
-                'hostRequires': 'fs/xml/hostrequires.xml',
-            },
-            {
-                'name': 'fs/xfs',
-                'tasks': 'fs/xml/xfstests-xfs-4k-finobt.xml',
-                "partitions": 'fs/xml/partitions.xml',
-            },
-        ]
-        self.assertListEqual(
-            expected_value,
-            list(targeted.get_all_test_cases(data.Base(self.db_dir)))
-        )
-
     def test_get_property(self):
         """Check properties are returned by test name"""
         database = data.Base(self.db_dir)

--- a/tests/test_targeted.py
+++ b/tests/test_targeted.py
@@ -12,7 +12,6 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Test cases for targeted module"""
-import re
 import os
 import tempfile
 import unittest
@@ -24,21 +23,6 @@ class TargetedTest(unittest.TestCase):
     def setUp(self):
         """Set common attributes used later on the test cases"""
         self.db_dir = os.path.join(os.path.dirname(__file__), 'assets')
-
-    def test_get_patterns(self):
-        """Check testcase patterns are read from the database"""
-        expected_value = [
-            {'pattern': re.compile('.*'), 'testcase_name': 'default/ltplite'},
-            {'pattern': re.compile('^fs/ext4/.*'), 'testcase_name': 'fs/ext4'},
-            {'pattern': re.compile('^fs/jbd2/.*'), 'testcase_name': 'fs/ext4'},
-            {'pattern': re.compile('^fs/xfs/.*'), 'testcase_name': 'fs/xfs'},
-            {'pattern': re.compile('^fs/[^/]*[ch]'),
-             'testcase_name': 'fs/xfs'},
-        ]
-        self.assertListEqual(
-            expected_value,
-            targeted.get_patterns(data.Base(self.db_dir))
-        )
 
     def test_get_src_files(self):
         """

--- a/tests/test_targeted.py
+++ b/tests/test_targeted.py
@@ -12,8 +12,8 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Test cases for targeted module"""
+import re
 import os
-import json
 import tempfile
 import unittest
 from kpet import targeted, data
@@ -25,21 +25,19 @@ class TargetedTest(unittest.TestCase):
         """Set common attributes used later on the test cases"""
         self.db_dir = os.path.join(os.path.dirname(__file__), 'assets')
 
-    def test_get_patterns_by_layout(self):
-        """Check patterns are readed from the layout"""
-        layout_path = os.path.join(self.db_dir, 'layout', 'layout.json')
-        with open(layout_path) as file_handler:
-            layout = json.load(file_handler)['testsuites']
+    def test_get_patterns(self):
+        """Check testcase patterns are read from the database"""
         expected_value = [
-            {'pattern': '.*', 'testcase_name': 'default/ltplite'},
-            {'pattern': '^fs/ext4/.*', 'testcase_name': 'fs/ext4'},
-            {'pattern': '^fs/jbd2/.*', 'testcase_name': 'fs/ext4'},
-            {'pattern': '^fs/xfs/.*', 'testcase_name': 'fs/xfs'},
-            {'pattern': '^fs/[^/]*[ch]', 'testcase_name': 'fs/xfs'},
+            {'pattern': re.compile('.*'), 'testcase_name': 'default/ltplite'},
+            {'pattern': re.compile('^fs/ext4/.*'), 'testcase_name': 'fs/ext4'},
+            {'pattern': re.compile('^fs/jbd2/.*'), 'testcase_name': 'fs/ext4'},
+            {'pattern': re.compile('^fs/xfs/.*'), 'testcase_name': 'fs/xfs'},
+            {'pattern': re.compile('^fs/[^/]*[ch]'),
+             'testcase_name': 'fs/xfs'},
         ]
         self.assertListEqual(
             expected_value,
-            targeted.get_patterns_by_layout(layout, self.db_dir)
+            targeted.get_patterns(data.Base(self.db_dir))
         )
 
     def test_get_src_files(self):

--- a/tox.ini
+++ b/tox.ini
@@ -30,4 +30,6 @@ whitelist_externals = pylint
 commands =
     # Disable R0801 in pylint that checks for duplicate content in multiple
     # files. See https://github.com/PyCQA/pylint/issues/214 for details.
-    pylint -d R0801 --ignored-classes=responses kpet tests
+    # Disable E0012 to make Python 2 pylint ignore useless-object-inheritance
+    # option, which is unknown to it, but is known to Python 3 pylint.
+    pylint -d E0012 -d R0801 --ignored-classes=responses kpet tests


### PR DESCRIPTION
This starts the rewrite of the database code to transition to lightweight object-oriented model with centralized schema validation. There are plenty of things that can be done with it, and the main being clearer, more maintainable code. Other things include:

* convert database to YAML (code is ready now!);
* refactor the database structure to have data objects reflect the reality better (tree/suite/testcase/patterns/etc. objects);
* store trees in the YAML files explicitly, allowing to list them directly (instead of listing templates) and attach properties to them;
* expose database objects to Jinja templates directly (I *assume* that's possible), so that the templates could iterate over them and access their properties, instead of mushing the data together into just a few variables, and so we don't have to create functions for every possible data item we might need (e.g. waived state or maintainer addresses);
* actually support schema versioning and conversion, so that we could upgrade it smoothly without losing compatibility
* support database merging, so we could have two databases: public with the majority of tests, and private with those we cannot or are yet to publish