### PR TITLE
workaround py3 exception

### DIFF
--- a/kpet/targeted.py
+++ b/kpet/targeted.py
@@ -189,5 +189,7 @@ def get_property(property_name, test_names, dbdir, required=False):
                 if required:
                     raise
                 continue
-            result.add(property_value)
+
+            if property_value is not None:
+                result.add(property_value)
     return result


### PR DESCRIPTION
Python3 doesn't allow to compare 'str' and NoneType. The code fails with
following trace that I haven't been able to reproduce locally:
```
1550047782.517421:ERROR:While executing command "run"
Traceback (most recent call last):
  File "/tmp/.local/bin/kpet", line 11, in <module>
    load_entry_point('kpet==1', 'console_scripts', 'kpet')()
  File "/tmp/.local/lib/python3.7/site-packages/kpet/__init__.py", line 195, in main
    exec_command(args, commands)
  File "/tmp/.local/lib/python3.7/site-packages/kpet/__init__.py", line 162, in exec_command
    command[0](*command[1:])
  File "/tmp/.local/lib/python3.7/site-packages/kpet/run.py", line 101, in main
    args.pw_cookie)
  File "/tmp/.local/lib/python3.7/site-packages/kpet/run.py", line 76, in generate
    targeted.get_property('partitions', test_names, dbdir)
TypeError: '<' not supported between instances of 'NoneType' and 'str'
```
The cause is likely 'partitions' being resolved to None somewhere.
For now, just lazily filter-out that None value.

Signed-off-by: Jakub Racek <jracek@redhat.com>