### PR TITLE
Allow test cases to request ignoring kernel panics

### DIFF
--- a/kpet/data.py
+++ b/kpet/data.py
@@ -15,7 +15,7 @@
 
 import os
 from kpet.schema import Invalid, Int, Struct, StrictStruct, \
-    List, Dict, String, Regex, ScopedYAMLFile, YAMLFile, Class
+    List, Dict, String, Regex, ScopedYAMLFile, YAMLFile, Class, Boolean
 
 # pylint: disable=raising-format-tuple
 
@@ -70,6 +70,7 @@ class TestSuite(Object):    # pylint: disable=too-few-public-methods
                             tasks=String()
                         ),
                         optional=dict(
+                            ignore_panic=Boolean(),
                             hostRequires=String(),
                             partitions=String(),
                             kickstart=String()

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -15,6 +15,7 @@
 import tempfile
 import shutil
 import os
+from functools import reduce
 from kpet import utils, targeted, data
 
 
@@ -76,6 +77,11 @@ def generate(template, template_params, patches, database, output,
     )
     template_params['TEST_CASES_KICKSTART'] = sorted(
         targeted.get_property('kickstart', test_names, database)
+    )
+    template_params['IGNORE_PANIC'] = reduce(
+        lambda x, y: x or y,
+        targeted.get_property('ignore_panic', test_names, database),
+        False
     )
     content = template.render(template_params)
     if not output:


### PR DESCRIPTION
Add support for specifying "ignore_panic" property for test cases, which
would request the test harness to ignore kernel panics for the whole
recipe.