### PR TITLE
Lower and enforce python version requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,6 @@ classifiers =
 packages = find:
 # Parse the MANIFEST.in file and include those files, too.
 include_package_data = True
-python_requires = ~=3.6
 test_suite = tests
 install_requires = requests
                    Jinja2

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
 packages = find:
 # Parse the MANIFEST.in file and include those files, too.
 include_package_data = True
-python_requires = ~=3.7
+python_requires = ~=3.6
 test_suite = tests
 install_requires = requests
                    Jinja2

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,18 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Install kpet using setuptools."""
+import sys
 from setuptools import setup
+
+python_required_major = 3
+python_required_minor = 6
+
+if sys.version_info.major < python_required_major or \
+   sys.version_info.major == python_required_major and \
+   sys.version_info.minor < python_required_minor:
+    sys.stderr.write("Python v{}.{} is required, but running v{}.{}".
+                     format(python_required_major, python_required_minor,
+                            sys.version_info.major, sys.version_info.minor))
+    sys.exit(1)
 
 setup()


### PR DESCRIPTION
Lower Python version requirements to v3.6, and make sure they're enforced even with the older versions of pip.