### PR TITLE
fix: run ci tests

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -3,7 +3,7 @@ envlist =
     flake8
     pylint
 
-[testenv:py36]
+[testenv]
 passenv = TRAVIS TRAVIS_*
 deps =
     coverage


### PR DESCRIPTION
The kpet CI tests aren't running for some reason. We're not getting
coverage reports or blocking on failed tests!
This is a fix attempt.

Signed-off-by: Jakub Racek <jracek@redhat.com>