### PR TITLE
Lint and reformat output XML

### DIFF
--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -97,6 +97,11 @@ def build_run_command(cmds_parser, common_parser):
         help='Patch series cover letter mbox URL/path'
     )
     generate_parser.add_argument(
+        '--no-lint',
+        action='store_true',
+        help='Do not lint and reformat output XML'
+    )
+    generate_parser.add_argument(
         'mboxes',
         nargs='*',
         default=[],

--- a/setup.cfg
+++ b/setup.cfg
@@ -23,6 +23,7 @@ test_suite = tests
 install_requires = requests
                    Jinja2
                    PyYAML
+                   lxml
 tests_require = mock
 
 [options.extras_require]

--- a/tests/assets/rhel7_rendered.xml
+++ b/tests/assets/rhel7_rendered.xml
@@ -1,36 +1,27 @@
+<?xml version='1.0' encoding='utf-8'?>
 <job>
   <whiteboard>Foo</whiteboard>
   <recipeSet>
-    
-      <recipe kernel_options="selinux=0">
+    <recipe kernel_options="selinux=0">
       <hostRequires>
-        
         <or>
           <labcontroller op="=" value="example1.com"/>
           <labcontroller op="=" value="example2.com"/>
           <labcontroller op="=" value="example3.com"/>
         </or>
-        
-          				<and>
-					<cpu_count op="&gt;" value="2"/>
-					<hypervisor op="=" value=""/>
-					<key_value key="DISKSPACE" op="&gt;=" value="50000"/>
-				</and>
-				<system_type value="Machine"/>
-        
-        
+        <and>
+          <cpu_count op="&gt;" value="2"/>
+          <hypervisor op="=" value=""/>
+          <key_value key="DISKSPACE" op="&gt;=" value="50000"/>
+        </and>
+        <system_type value="Machine"/>
       </hostRequires>
       <repos/>
       <partitions>
-        
-        
-          				<partition fs="xfs" name="/mnt/xfstests/mnt1" size="15" type="part"/>
-				<partition fs="xfs" name="/mnt/xfstests/mnt2" size="15" type="part"/>
-        
-        
+        <partition fs="xfs" name="/mnt/xfstests/mnt1" size="15" type="part"/>
+        <partition fs="xfs" name="/mnt/xfstests/mnt2" size="15" type="part"/>
       </partitions>
       <ks_appends/>
-      
       <task name="/distribution/install" role="STANDALONE">
         <params/>
       </task>
@@ -63,16 +54,9 @@
           <param name="KPKG_URL" value="bar"/>
         </params>
       </task>
-      
-        <task name="/kernel/distribution/ltp/lite" role="STANDALONE">
-	<fetch url="https://github.com/CKI-project/tests-beaker/archive/staging.zip#distribution/ltp/lite"/>
-</task>
-      
-        
-      
-        
-      
-      
-    
+      <task name="/kernel/distribution/ltp/lite" role="STANDALONE">
+        <fetch url="https://github.com/CKI-project/tests-beaker/archive/staging.zip#distribution/ltp/lite"/>
+      </task>
+    </recipe>
   </recipeSet>
 </job>

--- a/tests/assets/trees/rhel7.xml
+++ b/tests/assets/trees/rhel7.xml
@@ -61,6 +61,7 @@
         {% include test_case %}
       {% endfor %}
       {% endblock task %}
+    </recipe>
     {% endblock recipeSet %}
   </recipeSet>
 </job>

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -36,7 +36,7 @@ class RunTest(unittest.TestCase):
         database = data.Base(dbdir)
         template = database.get_tree_template('rhel7')
         with mock.patch('sys.stdout') as mock_stdout:
-            run.generate(template, template_params, [], database, None)
+            run.generate(template, template_params, [], database, True, None)
         with open(os.path.join(dbdir, 'rhel7_rendered.xml')) as file_handler:
             content_expected = file_handler.read()
         self.assertEqual(
@@ -45,7 +45,7 @@ class RunTest(unittest.TestCase):
         )
 
         tmpfile = tempfile.mktemp()
-        run.generate(template, template_params, [], database, tmpfile)
+        run.generate(template, template_params, [], database, True, tmpfile)
         with open(tmpfile) as tmp_handler:
             content = tmp_handler.read()
         self.assertEqual(
@@ -65,6 +65,7 @@ class RunTest(unittest.TestCase):
         mock_args.kernel = 'kernel'
         mock_args.arch = 'arch'
         mock_args.db = os.path.join(os.path.dirname(__file__), 'assets')
+        mock_args.no_lint = None
         mock_args.output = None
         mock_args.pw_cookie = None
         mock_args.description = 'description'
@@ -83,6 +84,7 @@ class RunTest(unittest.TestCase):
                 },
                 [],
                 mock.ANY,
+                True,
                 None,
                 None
             )


### PR DESCRIPTION
Support linting and reformatting the output XML, unless explicitly
disabled. Apart from making it easier for humans to interpret the output
XML, this will make it easier for us to track output changes as we
continue refactoring the code.

Supersedes #32.