### PR TITLE
Refine Jinja2 whitespace handling

### DIFF
--- a/kpet/data.py
+++ b/kpet/data.py
@@ -132,6 +132,9 @@ class Base(Object):     # pylint: disable=too-few-public-methods
         assert tree_name in self.trees
         jinja_env = jinja2.Environment(
             loader=jinja2.FileSystemLoader([self.dir_path]),
+            trim_blocks=True,
+            keep_trailing_newline=True,
+            lstrip_blocks=True,
             autoescape=jinja2.select_autoescape(
                 enabled_extensions=('xml'),
                 default_for_string=True,


### PR DESCRIPTION
Enable trimming newline after blocks, enable removing whitespace from
the start of the line to the block, and enable ensuring the output has a
trailing newline, in Jinja2 environment.

This works towards avoiding extra whitespace in reformatted output,
where LXML blank text removal heuristics is getting confused, such as
the "partitions" element having whitespace inside.