### PR TITLE
Support suite-level parameters

### DIFF
--- a/kpet/data.py
+++ b/kpet/data.py
@@ -62,13 +62,13 @@ class TestCase(Object):     # pylint: disable=too-few-public-methods
             Struct(
                 required=dict(
                     name=String(),
-                    tasks=String()
                 ),
                 optional=dict(
                     ignore_panic=Boolean(),
                     hostRequires=String(),
                     partitions=String(),
-                    kickstart=String()
+                    kickstart=String(),
+                    tasks=String(),
                 )
             ),
             data
@@ -79,12 +79,21 @@ class TestSuite(Object):    # pylint: disable=too-few-public-methods
     """Test suite"""
     def __init__(self, data):
         super().__init__(
-            StrictStruct(
-                description=String(),
-                version=String(),
-                patterns=List(StrictStruct(pattern=Regex(),
-                                           testcase_name=String())),
-                cases=List(Class(TestCase))
+            Struct(
+                required=dict(
+                    description=String(),
+                    version=String(),
+                    patterns=List(StrictStruct(pattern=Regex(),
+                                               testcase_name=String())),
+                    cases=List(Class(TestCase))
+                ),
+                optional=dict(
+                    tasks=String(),
+                    ignore_panic=Boolean(),
+                    hostRequires=String(),
+                    partitions=String(),
+                    kickstart=String()
+                )
             ),
             data
         )

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -14,7 +14,6 @@
 """KPET data"""
 
 import os
-from functools import reduce
 import jinja2
 from lxml import etree
 from kpet.schema import Invalid, Int, Struct, StrictStruct, \
@@ -260,30 +259,11 @@ class Base(Object):     # pylint: disable=too-few-public-methods
         assert isinstance(arch_name, str)
         assert isinstance(kernel_location, str)
 
-        case_set = self.match_case_set(src_path_set)
-
-        def get_property(name):
-            value_set = set()
-            for case in case_set:
-                value = getattr(case, name)
-                if value is not None:
-                    value_set.add(value)
-            return sorted(value_set)
-
         params = dict(
             DESCRIPTION=description,
             KURL=kernel_location,
             ARCH=arch_name,
             TREE=tree_name,
-            TEST_CASES=get_property('tasks'),
-            TEST_CASES_HOST_REQUIRES=get_property('hostRequires'),
-            TEST_CASES_PARTITIONS=get_property('partitions'),
-            TEST_CASES_KICKSTART=get_property('kickstart'),
-            IGNORE_PANIC=reduce(
-                lambda x, y: x or y,
-                get_property('ignore_panic'),
-                False
-            ),
             SRC_PATH_SET=src_path_set,
             SUITE_SET=set(self.testsuites.values()),
             match_suite_set=self.match_suite_set,


### PR DESCRIPTION
Allow suites to have the same parameters as cases have to support
suite-global settings and templates. Make case's tasks optional, as they
can now be defined at the suite level as well.