### PR TITLE
Support multihost jobs

### DIFF
--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -12,6 +12,7 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Module where the `run` command is implemented"""
+import sys
 import tempfile
 import shutil
 from kpet import misc, targeted, data, run
@@ -50,7 +51,7 @@ def main(args):
                                    kernel_location=args.kernel,
                                    lint=not args.no_lint)
         if not args.output:
-            print(content)
+            sys.stdout.write(content)
         else:
             with open(args.output, 'w') as file_handler:
                 file_handler.write(content)

--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -59,7 +59,7 @@ def main(args):
         src_files = get_src_files(args.patches, args.pw_cookie)
         case_name_list = sorted([case.name
                                  for case
-                                 in database.match_case_set(src_files)])
+                                 in database.match_case_list(src_files)])
         for case_name in case_name_list:
             print(case_name)
     else:

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -62,6 +62,7 @@ class Case(Object):     # pylint: disable=too-few-public-methods
                     name=String(),
                 ),
                 optional=dict(
+                    host_type_regex=Regex(),
                     ignore_panic=Boolean(),
                     hostRequires=String(),
                     partitions=String(),
@@ -85,6 +86,7 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
                     cases=List(Class(Case))
                 ),
                 optional=dict(
+                    host_type_regex=Regex(),
                     tasks=String(),
                     ignore_panic=Boolean(),
                     hostRequires=String(),
@@ -150,6 +152,29 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
         return bool(self.match_case_list(src_path_set))
 
 
+class HostType(Object):     # pylint: disable=too-few-public-methods
+    """Host type"""
+
+    def __init__(self, data):
+        """
+        Initialize a host type.
+        """
+        super().__init__(
+            Struct(optional=dict(
+                ignore_panic=Boolean(),
+                hostRequires=String(),
+                partitions=String(),
+                kickstart=String(),
+                tasks=String(),
+            )),
+            data
+        )
+
+
+# Host type to use when there are none defined
+DEFAULT_HOST_TYPE = HostType({})
+
+
 class Base(Object):     # pylint: disable=too-few-public-methods
     """Database"""
 
@@ -175,9 +200,15 @@ class Base(Object):     # pylint: disable=too-few-public-methods
 
         super().__init__(
             ScopedYAMLFile(
-                StrictStruct(
-                    suites=List(YAMLFile(Class(Suite))),
-                    trees=Dict(String())
+                Struct(
+                    required=dict(
+                        suites=List(YAMLFile(Class(Suite))),
+                        trees=Dict(String()),
+                    ),
+                    optional=dict(
+                        host_types=Dict(Class(HostType)),
+                        host_type_regex=Regex()
+                    )
                 )
             ),
             dir_path + "/index.yaml"

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -14,7 +14,7 @@
 """KPET data"""
 
 import os
-from kpet.schema import Invalid, Int, Struct, StrictStruct, Ancestry, \
+from kpet.schema import Invalid, Int, Struct, StrictStruct, \
     List, Dict, String, Regex, ScopedYAMLFile, YAMLFile, Class, Boolean
 
 # pylint: disable=raising-format-tuple
@@ -188,26 +188,12 @@ class Base(Object):     # pylint: disable=too-few-public-methods
         """
         assert self.is_dir_valid(dir_path)
 
-        def convert(old_data):
-            """Convert the data from old to new format"""
-            data = old_data.copy()
-            data['suites'] = list(data['suites'].values())
-            return data
-
         super().__init__(
             ScopedYAMLFile(
-                Ancestry(
-                    StrictStruct(
-                        schema=StrictStruct(version=Int()),
-                        suites=Dict(YAMLFile(Class(Suite))),
-                        trees=Dict(String())
-                    ),
-                    convert,
-                    StrictStruct(
-                        schema=StrictStruct(version=Int()),
-                        suites=List(YAMLFile(Class(Suite))),
-                        trees=Dict(String())
-                    )
+                StrictStruct(
+                    schema=StrictStruct(version=Int()),
+                    suites=List(YAMLFile(Class(Suite))),
+                    trees=Dict(String())
                 )
             ),
             dir_path + "/index.yaml"

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -14,7 +14,7 @@
 """KPET data"""
 
 import os
-from kpet.schema import Invalid, Int, Struct, StrictStruct, \
+from kpet.schema import Invalid, Struct, StrictStruct, \
     List, Dict, String, Regex, ScopedYAMLFile, YAMLFile, Class, Boolean
 
 # pylint: disable=raising-format-tuple
@@ -80,7 +80,6 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
             Struct(
                 required=dict(
                     description=String(),
-                    version=String(),
                     patterns=List(StrictStruct(pattern=Regex(),
                                                case_name=String())),
                     cases=List(Class(Case))
@@ -191,7 +190,6 @@ class Base(Object):     # pylint: disable=too-few-public-methods
         super().__init__(
             ScopedYAMLFile(
                 StrictStruct(
-                    schema=StrictStruct(version=Int()),
                     suites=List(YAMLFile(Class(Suite))),
                     trees=Dict(String())
                 )

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -135,20 +135,6 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
             case_list = self.cases.copy()
         return case_list
 
-    def match_case_set(self, src_path_set):
-        """
-        Return a set of test cases responsible for testing any files in a set.
-
-        Args:
-            src_path_set:   A set of source file paths to match cases against,
-                            or an empty set for all source files.
-
-        Returns:
-            A set of test cases responsible for testing at least some of the
-            specified files.
-        """
-        return set(self.match_case_list(src_path_set))
-
     def matches(self, src_path_set):
         """
         Check if the suite is responsible for testing any files in a set.
@@ -161,7 +147,7 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
             True if the suite is responsible for testing at least some of
             the specified files.
         """
-        return bool(self.match_case_set(src_path_set))
+        return bool(self.match_case_list(src_path_set))
 
 
 class Base(Object):     # pylint: disable=too-few-public-methods
@@ -214,21 +200,6 @@ class Base(Object):     # pylint: disable=too-few-public-methods
         """
         return [suite for suite in self.suites if suite.matches(src_path_set)]
 
-    def match_suite_set(self, src_path_set):
-        """
-        Return a set of test suites responsible for testing any files in a
-        set.
-
-        Args:
-            src_path_set:   A set of source file paths to match suites
-                            against, or an empty set for all files.
-
-        Returns:
-            A set of test suites responsible for testing at least some of the
-            specified files.
-        """
-        return set(self.match_suite_list(src_path_set))
-
     def match_case_list(self, src_path_set):
         """
         Return a list of test cases responsible for testing any files in a
@@ -246,17 +217,3 @@ class Base(Object):     # pylint: disable=too-few-public-methods
         for suite in self.suites:
             case_list += suite.match_case_list(src_path_set)
         return case_list
-
-    def match_case_set(self, src_path_set):
-        """
-        Return a set of test cases responsible for testing any files in a set.
-
-        Args:
-            src_path_set:   A set of source file paths to match cases against,
-                            or an empty set for all source files.
-
-        Returns:
-            A set of test cases responsible for testing at least some of the
-            specified files.
-        """
-        return set(self.match_case_list(src_path_set))

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -130,7 +130,7 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
                 for src_path in src_path_set:
                     if pattern['pattern'].match(src_path):
                         case = self.get_case(pattern['case_name'])
-                        if case:
+                        if case and case not in case_list:
                             case_list.append(case)
         else:
             case_list = self.cases.copy()

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -89,11 +89,7 @@ class Base:     # pylint: disable=too-few-public-methods
             KURL=kernel_location,
             ARCH=arch_name,
             TREE=tree_name,
-            SRC_PATH_SET=self.src_path_set,
-            SUITE_SET=set(self.database.suites),
             SUITES=self.suites,
-            match_suite_set=self.database.match_suite_set,
-            match_case_set=self.database.match_case_set,
             getenv=os.getenv,
         )
 

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -94,7 +94,11 @@ class Base:     # pylint: disable=too-few-public-methods
                 Host(
                     data.DEFAULT_HOST_TYPE,
                     [
-                        Suite(suite, suite.match_case_list(src_path_set))
+                        Suite(
+                            suite,
+                            suite.match_case_list(database.specific,
+                                                  src_path_set)
+                        )
                         for suite in
                         database.match_suite_list(src_path_set)
                     ]
@@ -103,7 +107,8 @@ class Base:     # pylint: disable=too-few-public-methods
 
         # Build a pool of suites and cases
         pool_suites = [
-            (suite, suite.match_case_list(src_path_set))
+            (suite,
+             suite.match_case_list(database.specific, src_path_set))
             for suite
             in database.match_suite_list(src_path_set)
         ]
@@ -154,7 +159,10 @@ class Base:     # pylint: disable=too-few-public-methods
         self.src_path_set = src_path_set
         # TODO: Remove once templates no longer use it
         self.suites = [
-            Suite(suite, suite.match_case_list(src_path_set))
+            Suite(
+                suite,
+                suite.match_case_list(self.database.specific, src_path_set)
+            )
             for suite
             in self.database.match_suite_list(src_path_set)
         ]

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -19,6 +19,31 @@ from lxml import etree
 from kpet import data
 
 
+class Suite:    # pylint: disable=too-few-public-methods
+    """A test suite run"""
+
+    def __init__(self, suite, cases):
+        """
+        Initialize a test suite run.
+
+        Args:
+            suite:          The suite to run.
+            cases:          List of the suite's cases to run.
+        """
+        assert isinstance(suite, data.Suite)
+        assert isinstance(cases, list)
+        for case in cases:
+            assert case in suite.cases
+
+        self.description = suite.description
+        self.tasks = suite.tasks
+        self.ignore_panic = suite.ignore_panic
+        self.hostRequires = suite.hostRequires  # pylint: disable=invalid-name
+        self.partitions = suite.partitions
+        self.kickstart = suite.kickstart
+        self.cases = cases
+
+
 class Base:     # pylint: disable=too-few-public-methods
     """A specific execution of tests in a database"""
 
@@ -36,7 +61,9 @@ class Base:     # pylint: disable=too-few-public-methods
         assert isinstance(database, data.Base)
         self.database = database
         self.src_path_set = src_path_set
-        self.suites = self.database.match_suite_list(src_path_set)
+        self.suites = [Suite(suite, suite.match_case_list(src_path_set))
+                       for suite
+                       in self.database.match_suite_list(src_path_set)]
 
     # pylint: disable=too-many-arguments
     def generate(self, description, tree_name, arch_name,

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -36,7 +36,6 @@ class SuiteRun:
         """
         assert isinstance(suite, data.Suite)
         self.description = suite.description
-        self.version = suite.version
         self.tasks = suite.tasks
         self.ignore_panic = suite.ignore_panic
         self.hostRequires = suite.hostRequires  # pylint: disable=invalid-name

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -19,31 +19,6 @@ from lxml import etree
 from kpet import data
 
 
-# pylint: disable=too-few-public-methods,too-many-instance-attributes
-class SuiteRun:
-    """An execution of a test suite"""
-
-    def __init__(self, suite, src_path_set):
-        """
-        Initialize an instance of a test suite run.
-
-        Args:
-            suite:              The data for the suite to run.
-            src_path_set:       A set of paths to source files the executed
-                                tests should cover, empty set for all files.
-                                Affects the selection of test suites and test
-                                cases to run.
-        """
-        assert isinstance(suite, data.Suite)
-        self.description = suite.description
-        self.tasks = suite.tasks
-        self.ignore_panic = suite.ignore_panic
-        self.hostRequires = suite.hostRequires  # pylint: disable=invalid-name
-        self.partitions = suite.partitions
-        self.kickstart = suite.kickstart
-        self.cases = suite.match_case_list(src_path_set)
-
-
 class Base:     # pylint: disable=too-few-public-methods
     """A specific execution of tests in a database"""
 

--- a/tests/assets/index.yaml
+++ b/tests/assets/index.yaml
@@ -4,5 +4,5 @@ trees:
     rhel7: trees/rhel7.xml
     rhel8: trees/rhel8.xml
 suites:
-    default: suites/default/index.yaml
-    fs: suites/fs/index.yaml
+    - suites/default/index.yaml
+    - suites/fs/index.yaml

--- a/tests/assets/trees/rhel7.xml
+++ b/tests/assets/trees/rhel7.xml
@@ -1,3 +1,15 @@
+{% macro include_templates(template_field) -%}
+  {% for suite in SUITES %}
+    {% if suite[template_field] %}
+      {% include suite[template_field] %}
+    {% endif %}
+    {% for case in suite.cases %}
+      {% if case[template_field] %}
+        {% include case[template_field] %}
+      {% endif %}
+    {% endfor %}
+  {% endfor %}
+{% endmacro %}
 <job>
   <whiteboard>{{ DESCRIPTION }}</whiteboard>
   <recipeSet>
@@ -8,15 +20,11 @@
           <labcontroller op="=" value="example2.com"/>
           <labcontroller op="=" value="example3.com"/>
         </or>
-        {% for case in match_case_set(SRC_PATH_SET) if case.hostRequires %}
-          {% include case.hostRequires %}
-        {% endfor %}
+        {{- include_templates('hostRequires') -}}
       </hostRequires>
       <repos/>
       <partitions>
-        {% for case in match_case_set(SRC_PATH_SET) if case.partitions %}
-          {% include case.partitions %}
-        {% endfor %}
+        {{- include_templates('partitions') -}}
       </partitions>
       <ks_appends/>
       <task name="/distribution/install" role="STANDALONE">
@@ -51,9 +59,7 @@
           <param name="KPKG_URL" value="{{ KURL }}"/>
         </params>
       </task>
-      {% for case in match_case_set(SRC_PATH_SET) if case.tasks %}
-        {% include case.tasks %}
-      {% endfor %}
+      {{- include_templates('tasks') -}}
     </recipe>
   </recipeSet>
 </job>

--- a/tests/assets/trees/rhel7.xml
+++ b/tests/assets/trees/rhel7.xml
@@ -1,10 +1,8 @@
-{% block jobDefinition %}<job>{% endblock %}
+<job>
   <whiteboard>{{ DESCRIPTION }}</whiteboard>
   <recipeSet>
-    {% block recipeSet %}
-      {% block recipeDefinition %}<recipe kernel_options="selinux=0">{% endblock %}
+    <recipe kernel_options="selinux=0">
       <hostRequires>
-        {% block hostRequires %}
         <or>
           <labcontroller op="=" value="example1.com"/>
           <labcontroller op="=" value="example2.com"/>
@@ -13,18 +11,14 @@
         {% for case in match_case_set(SRC_PATH_SET) if case.hostRequires %}
           {% include case.hostRequires %}
         {% endfor %}
-        {% endblock hostRequires %}
       </hostRequires>
       <repos/>
       <partitions>
-        {% block partitions %}
         {% for case in match_case_set(SRC_PATH_SET) if case.partitions %}
           {% include case.partitions %}
         {% endfor %}
-        {% endblock partitions %}
       </partitions>
       <ks_appends/>
-      {% block task %}
       <task name="/distribution/install" role="STANDALONE">
         <params/>
       </task>
@@ -60,8 +54,6 @@
       {% for case in match_case_set(SRC_PATH_SET) if case.tasks %}
         {% include case.tasks %}
       {% endfor %}
-      {% endblock task %}
     </recipe>
-    {% endblock recipeSet %}
   </recipeSet>
 </job>


### PR DESCRIPTION
This brings support for producing multi-host jobs, as well as support for excluding test cases from baseline runs. This also fixes a couple issues I introduced in previous PRs, prepares us for removing unused versions from kpet-db, and removes support for legacy data.