### PR TITLE
allow specifying url_suffix per-case

### DIFF
--- a/kpet/data.py
+++ b/kpet/data.py
@@ -214,6 +214,7 @@ class Case(Object):     # pylint: disable=too-few-public-methods
                     dont_match=Class(NegativePattern),
                     waived=Boolean(),
                     role=String(),
+                    url_suffix=String(),
                     task_params=Dict(String()),
                 )
             ),

--- a/tests/assets/db/general/trees/rhel7.xml
+++ b/tests/assets/db/general/trees/rhel7.xml
@@ -5,9 +5,13 @@
   {% for suite in host.suites %}
     {% for case in suite.cases %}
         <task name="{{ case['name'] }}" role="{{ case['role'] }}">
-          {% if suite['url_suffix'] is not none %}
-              <fetch url="{{ TESTS_BEAKER_ZIP_URL }}#{{ suite['url_suffix'] }}"/>
-          {% endif %}
+            {% if case['url_suffix'] is not none %}
+                <fetch url="{{ TESTS_BEAKER_ZIP_URL }}#{{ case['url_suffix'] }}"/>
+            {% else %}
+                {% if suite['url_suffix'] is not none %}
+                    <fetch url="{{ TESTS_BEAKER_ZIP_URL }}#{{ suite['url_suffix'] }}"/>
+                {% endif %}
+            {% endif %}
             <params>
               {% if case['waived'] is not none %}
                 <param name="_WAIVED" value="{{ case['waived'] }}"/>


### PR DESCRIPTION
Currently, if url_suffix is set in suite, all cases get tests-beaker
fetch element, with url_suffix set. If url_suffix is missing, the fetch
element is not present.

This patch allows to set url_suffix per-case. If it is present in both
suite and case, then case overrides suite.

This requires complementary kpet-db change.

Signed-off-by: Jakub Racek <jracek@redhat.com>