### PR TITLE
enforce maximum test runtime

### DIFF
--- a/kpet/data.py
+++ b/kpet/data.py
@@ -15,7 +15,7 @@
 
 import os
 from kpet.schema import Invalid, Struct, Reduction, NonEmptyList, \
-    List, Dict, String, Regex, ScopedYAMLFile, YAMLFile, Class, Boolean
+    List, Dict, String, Regex, ScopedYAMLFile, YAMLFile, Class, Boolean, Int
 
 # pylint: disable=raising-format-tuple,access-member-before-definition
 
@@ -216,6 +216,7 @@ class Case(Object):     # pylint: disable=too-few-public-methods
                     role=String(),
                     url_suffix=String(),
                     task_params=Dict(String()),
+                    max_duration_minutes=Int(),
                 )
             ),
             data


### PR DESCRIPTION
This and complementary change in kpet-db implements FASTMOVING-777.

This adds optional Suite attribute 'max_runtime_minutes', which sets
RSTRNT_MAX_TIME, which is the maximum amount of time the test is allowed
to run. If it exceeds this amount of time, it is cancelled by restraint
harness.

Signed-off-by: Jakub Racek <jracek@redhat.com>