### PR TITLE
add hostname attribute for overwriting hostRequires

### DIFF
--- a/kpet/data.py
+++ b/kpet/data.py
@@ -296,6 +296,7 @@ class HostType(Object):     # pylint: disable=too-few-public-methods
             Struct(optional=dict(
                 ignore_panic=Boolean(),
                 hostRequires=String(),
+                hostname=String(),
                 partitions=String(),
                 kickstart=String(),
                 tasks=String(),

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -47,7 +47,8 @@ class Suite:
         self.url_suffix = suite.url_suffix
 
 
-class Host:     # pylint: disable=too-few-public-methods
+class Host:
+    # pylint: disable=too-few-public-methods, too-many-instance-attributes
     """A host running test suites"""
 
     # pylint: disable=redefined-builtin
@@ -74,6 +75,7 @@ class Host:     # pylint: disable=too-few-public-methods
         self.suites = suites
 
         self.name = name
+        self.hostname = type.hostname
 
 
 class Base:     # pylint: disable=too-few-public-methods


### PR DESCRIPTION
This is kpet change necessary to implement FASTMOVING-740.

This patch adds hostname attribute into host/host type.

This allows kpet-db jinja template to insert <hostRequires force="..." />
element insteadof any normal hostRequires.
This change is independent from kpet-db, but in order to work, kpet-db
needs tiny either/or change in template.

Signed-off-by: Jakub Racek <jracek@redhat.com>