### PR TITLE
Handle UTF-8 characters in patches

### DIFF
--- a/kpet/targeted.py
+++ b/kpet/targeted.py
@@ -64,8 +64,8 @@ def get_src_files(patch_path_list):
                          re.MULTILINE)
     file_set = set()
     for patch_path in patch_path_list:
-        with open(patch_path) as patch_file:
-            patch_content = patch_file.read()
+        with open(patch_path, 'rb') as patch_file:
+            patch_content = patch_file.read().decode('utf-8')
             patch_file_set = set()
             for match in re.finditer(pattern, patch_content):
                 if match.group(0) == "---":


### PR DESCRIPTION
Reading a patch with UTF-8 characters causes unicode errors in
Python. This patch changes the file handle to binary mode and
decodes the byte string back to a regular string right after.

Patch to test with: https://git.kernel.org/pub/scm/linux/kernel/git/stable/stable-queue.git/plain/queue-5.0/sch_cake-use-tc_skb_protocol-helper-for-getting-packet-protocol.patch

Signed-off-by: Major Hayden <major@redhat.com>