### PR TITLE
Detect patch character encoding dynamically

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ install_requires = requests
                    Jinja2
                    PyYAML
                    lxml
+                   chardet
 tests_require = mock
 
 [options.extras_require]


### PR DESCRIPTION
Most patches are plain ASCII, but some are ISO-8859-1 and some are
UTF-8. We must detect the encoding before we can decode the byte
string and apply regularly expressions to the patch text.

Signed-off-by: Major Hayden <major@redhat.com>