### PR TITLE
rename max_duration_minutes to max_duration_seconds

### DIFF
--- a/kpet/data.py
+++ b/kpet/data.py
@@ -216,7 +216,7 @@ class Case(Object):     # pylint: disable=too-few-public-methods
                     role=String(),
                     url_suffix=String(),
                     task_params=Dict(String()),
-                    max_duration_minutes=Int(),
+                    max_duration_seconds=Int(),
                 )
             ),
             data


### PR DESCRIPTION
The restraint variable is apparently in seconds, so let's rename our
variable.

Signed-off-by: Jakub Racek <jracek@redhat.com>