### PR TITLE
make max_duration_seconds mandatory

### DIFF
--- a/kpet/data.py
+++ b/kpet/data.py
@@ -202,6 +202,7 @@ class Case(Object):     # pylint: disable=too-few-public-methods
             Struct(
                 required=dict(
                     name=String(),
+                    max_duration_seconds=Int(),
                 ),
                 optional=dict(
                     host_type_regex=Regex(),
@@ -216,7 +217,6 @@ class Case(Object):     # pylint: disable=too-few-public-methods
                     role=String(),
                     url_suffix=String(),
                     task_params=Dict(String()),
-                    max_duration_seconds=Int(),
                 )
             ),
             data

--- a/tests/assets/db/empty/case_no_patterns/suite.yaml
+++ b/tests/assets/db/empty/case_no_patterns/suite.yaml
@@ -3,3 +3,4 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600

--- a/tests/assets/db/empty/case_with_a_pattern/suite.yaml
+++ b/tests/assets/db/empty/case_with_a_pattern/suite.yaml
@@ -3,3 +3,4 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600

--- a/tests/assets/db/general/suites/default/index.yaml
+++ b/tests/assets/db/general/suites/default/index.yaml
@@ -4,3 +4,4 @@ maintainers:
 url_suffix: distribution/ltp/lite
 cases:
     -   name: /kernel/distribution/ltp/lite
+        max_duration_seconds: 600

--- a/tests/assets/db/general/suites/fs/index.yaml
+++ b/tests/assets/db/general/suites/fs/index.yaml
@@ -5,6 +5,7 @@ maintainers:
 cases:
     -   hostRequires: suites/fs/hostrequires.xml
         name: fs/ext4
+        max_duration_seconds: 600
         match:
           sources:
             - ^fs/ext4/.*
@@ -12,6 +13,7 @@ cases:
 
     -   name: fs/xfs
         partitions: suites/fs/partitions.xml
+        max_duration_seconds: 600
         match:
           sources:
             - ^fs/xfs/.*

--- a/tests/assets/db/match/arches/no_patterns/suite.yaml
+++ b/tests/assets/db/match/arches/no_patterns/suite.yaml
@@ -3,5 +3,6 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
           arches: []

--- a/tests/assets/db/match/arches/one_pattern/suite.yaml
+++ b/tests/assets/db/match/arches/one_pattern/suite.yaml
@@ -3,5 +3,6 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
           arches: arch

--- a/tests/assets/db/match/arches/two_patterns/suite.yaml
+++ b/tests/assets/db/match/arches/two_patterns/suite.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
           arches:
               - arch

--- a/tests/assets/db/match/location_types/no_patterns/suite.yaml
+++ b/tests/assets/db/match/location_types/no_patterns/suite.yaml
@@ -3,5 +3,6 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
           location_types: []

--- a/tests/assets/db/match/location_types/one_pattern/suite.yaml
+++ b/tests/assets/db/match/location_types/one_pattern/suite.yaml
@@ -3,20 +3,26 @@ maintainers:
   - maint1
 cases:
     - name: tarball-path
+      max_duration_seconds: 600
       match:
           location_types: tarball-path
     - name: rpm-path
+      max_duration_seconds: 600
       match:
           location_types: rpm-path
     - name: repo-path
+      max_duration_seconds: 600
       match:
           location_types: repo-path
     - name: tarball-url
+      max_duration_seconds: 600
       match:
           location_types: tarball-url
     - name: rpm-url
+      max_duration_seconds: 600
       match:
           location_types: rpm-url
     - name: repo-url
+      max_duration_seconds: 600
       match:
           location_types: repo-url

--- a/tests/assets/db/match/location_types/two_patterns/suite.yaml
+++ b/tests/assets/db/match/location_types/two_patterns/suite.yaml
@@ -3,16 +3,19 @@ maintainers:
   - maint1
 cases:
     - name: tarball
+      max_duration_seconds: 600
       match:
           location_types:
               - tarball-path
               - tarball-url
     - name: rpm
+      max_duration_seconds: 600
       match:
           location_types:
               - rpm-path
               - rpm-url
     - name: repo
+      max_duration_seconds: 600
       match:
           location_types:
               - repo-path

--- a/tests/assets/db/match/sources/one_case/no_patterns/suite.yaml
+++ b/tests/assets/db/match/sources/one_case/no_patterns/suite.yaml
@@ -3,3 +3,4 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600

--- a/tests/assets/db/match/sources/one_case/one_pattern/suite.yaml
+++ b/tests/assets/db/match/sources/one_case/one_pattern/suite.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
         sources:
           - a

--- a/tests/assets/db/match/sources/one_case/two_patterns/suite.yaml
+++ b/tests/assets/db/match/sources/one_case/two_patterns/suite.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
         sources:
           - a

--- a/tests/assets/db/match/sources/specific/case/suite1.yaml
+++ b/tests/assets/db/match/sources/specific/case/suite1.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
           specific_sources: true
           sources: a

--- a/tests/assets/db/match/sources/specific/case/suite2.yaml
+++ b/tests/assets/db/match/sources/specific/case/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       match:
         sources:
           - d

--- a/tests/assets/db/match/sources/specific/suite/suite1.yaml
+++ b/tests/assets/db/match/sources/specific/suite/suite1.yaml
@@ -5,5 +5,6 @@ match:
     specific_sources: true
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
           sources: a

--- a/tests/assets/db/match/sources/specific/suite/suite2.yaml
+++ b/tests/assets/db/match/sources/specific/suite/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       match:
         sources:
           - d

--- a/tests/assets/db/match/sources/two_cases/suite.yaml
+++ b/tests/assets/db/match/sources/two_cases/suite.yaml
@@ -3,10 +3,12 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
         sources:
           - a
     - name: case2
+      max_duration_seconds: 600
       match:
         sources:
           - d

--- a/tests/assets/db/match/sources/two_suites/suite1.yaml
+++ b/tests/assets/db/match/sources/two_suites/suite1.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
         sources:
           - a

--- a/tests/assets/db/match/sources/two_suites/suite2.yaml
+++ b/tests/assets/db/match/sources/two_suites/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       match:
         sources:
           - d

--- a/tests/assets/db/match/trees/no_patterns/suite.yaml
+++ b/tests/assets/db/match/trees/no_patterns/suite.yaml
@@ -3,5 +3,6 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
           trees: []

--- a/tests/assets/db/match/trees/one_pattern/suite.yaml
+++ b/tests/assets/db/match/trees/one_pattern/suite.yaml
@@ -3,5 +3,6 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
           trees: tree

--- a/tests/assets/db/match/trees/two_patterns/suite.yaml
+++ b/tests/assets/db/match/trees/two_patterns/suite.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
           trees:
               - tree

--- a/tests/assets/db/multihost/no_types/db_regex/suite1.yaml
+++ b/tests/assets/db/multihost/no_types/db_regex/suite1.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
         sources:
           - a

--- a/tests/assets/db/multihost/no_types/db_regex/suite2.yaml
+++ b/tests/assets/db/multihost/no_types/db_regex/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       match:
         sources:
           - d

--- a/tests/assets/db/multihost/no_types/no_regex/two_suites/suite1.yaml
+++ b/tests/assets/db/multihost/no_types/no_regex/two_suites/suite1.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
         sources:
           - a

--- a/tests/assets/db/multihost/no_types/no_regex/two_suites/suite2.yaml
+++ b/tests/assets/db/multihost/no_types/no_regex/two_suites/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       match:
         sources:
           - d

--- a/tests/assets/db/multihost/one_type/case_regex/suite1.yaml
+++ b/tests/assets/db/multihost/one_type/case_regex/suite1.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       host_type_regex: normal
       match:
         sources:

--- a/tests/assets/db/multihost/one_type/case_regex/suite2.yaml
+++ b/tests/assets/db/multihost/one_type/case_regex/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       host_type_regex: not_normal
       match:
         sources:

--- a/tests/assets/db/multihost/one_type/db_regex/suite1.yaml
+++ b/tests/assets/db/multihost/one_type/db_regex/suite1.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
         sources:
           - a

--- a/tests/assets/db/multihost/one_type/db_regex/suite2.yaml
+++ b/tests/assets/db/multihost/one_type/db_regex/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       match:
         sources:
           - d

--- a/tests/assets/db/multihost/one_type/no_regex/two_suites/suite1.yaml
+++ b/tests/assets/db/multihost/one_type/no_regex/two_suites/suite1.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
         sources:
           - a

--- a/tests/assets/db/multihost/one_type/no_regex/two_suites/suite2.yaml
+++ b/tests/assets/db/multihost/one_type/no_regex/two_suites/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       match:
         sources:
           - d

--- a/tests/assets/db/multihost/one_type/suite_regex/suite1.yaml
+++ b/tests/assets/db/multihost/one_type/suite_regex/suite1.yaml
@@ -4,6 +4,7 @@ maintainers:
 host_type_regex: normal
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
         sources:
           - a

--- a/tests/assets/db/multihost/one_type/suite_regex/suite2.yaml
+++ b/tests/assets/db/multihost/one_type/suite_regex/suite2.yaml
@@ -4,6 +4,7 @@ maintainers:
 host_type_regex: not_normal
 cases:
     - name: case2
+      max_duration_seconds: 600
       match:
         sources:
           - d

--- a/tests/assets/db/multihost/one_type/wrong_regex/suite1.yaml
+++ b/tests/assets/db/multihost/one_type/wrong_regex/suite1.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       match:
         sources:
           - a

--- a/tests/assets/db/multihost/one_type/wrong_regex/suite2.yaml
+++ b/tests/assets/db/multihost/one_type/wrong_regex/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       match:
         sources:
           - d

--- a/tests/assets/db/multihost/two_types/both_cases_both/suite1.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_both/suite1.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       host_type_regex: ""
       match:
         sources:

--- a/tests/assets/db/multihost/two_types/both_cases_both/suite2.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_both/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       host_type_regex: ""
       match:
         sources:

--- a/tests/assets/db/multihost/two_types/both_cases_first/suite1.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_first/suite1.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       host_type_regex: a
       match:
         sources:

--- a/tests/assets/db/multihost/two_types/both_cases_first/suite2.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_first/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       host_type_regex: a
       match:
         sources:

--- a/tests/assets/db/multihost/two_types/both_cases_second/suite1.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_second/suite1.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       host_type_regex: b
       match:
         sources:

--- a/tests/assets/db/multihost/two_types/both_cases_second/suite2.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_second/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       host_type_regex: b
       match:
         sources:

--- a/tests/assets/db/multihost/two_types/one_case_each/suite1.yaml
+++ b/tests/assets/db/multihost/two_types/one_case_each/suite1.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case1
+      max_duration_seconds: 600
       host_type_regex: a
       match:
         sources:

--- a/tests/assets/db/multihost/two_types/one_case_each/suite2.yaml
+++ b/tests/assets/db/multihost/two_types/one_case_each/suite2.yaml
@@ -3,6 +3,7 @@ maintainers:
   - maint1
 cases:
     - name: case2
+      max_duration_seconds: 600
       host_type_regex: b
       match:
         sources:


### PR DESCRIPTION
This is a followup for https://github.com/CKI-project/kpet/pull/67.
This patch makes max_duration_seconds mandatory, so that we can
implement scheduling later on.
The related kpet-db MR was merged, so all tests have this and from now
on, all new tests have to have this.

Signed-off-by: Jakub Racek <jracek@redhat.com>