### PR TITLE
Support test sets

### DIFF
--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -16,7 +16,7 @@ import argparse
 import os
 import sys
 import logging
-from kpet import cmd_run, cmd_tree, cmd_arch
+from kpet import cmd_run, cmd_tree, cmd_arch, cmd_set
 
 
 def exec_command(args, commands):
@@ -53,6 +53,7 @@ def main(args=None):
     cmd_run.build(cmds_parser, common_parser)
     cmd_tree.build(cmds_parser, common_parser)
     cmd_arch.build(cmds_parser, common_parser)
+    cmd_set.build(cmds_parser, common_parser)
 
     args = parser.parse_args(args)
     commands = {
@@ -60,5 +61,6 @@ def main(args=None):
         'run': [cmd_run.main, args],
         'tree': [cmd_tree.main, args],
         'arch': [cmd_arch.main, args],
+        'set': [cmd_set.main, args],
     }
     exec_command(args, commands)

--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -75,12 +75,6 @@ def build(cmds_parser, common_parser):
         help='Kernel location. Must be accessible by Beaker. Required.'
     )
     generate_parser.add_argument(
-        '-c',
-        '--cover-letter',
-        default='no cover letter',
-        help='Patch series cover letter mbox URL/path'
-    )
-    generate_parser.add_argument(
         '--no-lint',
         action='store_true',
         help='Do not lint and reformat output XML'

--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -52,13 +52,15 @@ def build(cmds_parser, common_parser):
         '-t',
         '--tree',
         required=True,
-        help='kernel "tree" name, chosen from "tree list" output, or "MAIL"'
+        help='Name of the specified kernel\'s tree. Required. ' +
+        'See "kpet tree list" for recognized trees.'
     )
     generate_parser.add_argument(
         '-a',
         '--arch',
         default='x86_64',
-        help='An architecture chosen from "arch list" output'
+        help='Architecture of the specified kernel. Required. ' +
+        'See "kpet arch list" for supported architectures.'
     )
     generate_parser.add_argument(
         '--type',
@@ -70,7 +72,7 @@ def build(cmds_parser, common_parser):
         '-k',
         '--kernel',
         required=True,
-        help='Kernel location'
+        help='Kernel location. Must be accessible by Beaker. Required.'
     )
     generate_parser.add_argument(
         '-c',

--- a/kpet/cmd_set.py
+++ b/kpet/cmd_set.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2018 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""The "set" command"""
+from kpet import misc, data, cmd_misc
+
+
+def build(cmds_parser, common_parser):
+    """Build the argument parser for the set command"""
+    _, action_subparser = cmd_misc.build(
+        cmds_parser,
+        common_parser,
+        "set",
+        help='Test set, default action "list".',
+    )
+    action_subparser.add_parser(
+        "list",
+        help='List available test sets.',
+        parents=[common_parser],
+    )
+
+
+def main(args):
+    """Main function for the `set` command"""
+    if not data.Base.is_dir_valid(args.db):
+        raise Exception("\"{}\" is not a database directory".format(args.db))
+    database = data.Base(args.db)
+    if args.action == 'list':
+        max_name_length = max(len(k) for k in database.sets)
+        for name, description in sorted(database.sets.items(),
+                                        key=lambda i: i[0]):
+            print(f"{name: <{max_name_length}} {description}")
+    else:
+        misc.raise_action_not_found(args.action, args.command)

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -206,7 +206,6 @@ class Case(Object):     # pylint: disable=too-few-public-methods
                 ),
                 optional=dict(
                     host_type_regex=Regex(),
-                    ignore_panic=Boolean(),
                     hostRequires=String(),
                     partitions=String(),
                     kickstart=String(),
@@ -256,7 +255,6 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
                 optional=dict(
                     host_type_regex=Regex(),
                     tasks=String(),
-                    ignore_panic=Boolean(),
                     hostRequires=String(),
                     partitions=String(),
                     kickstart=String(),

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -209,7 +209,6 @@ class Case(Object):     # pylint: disable=too-few-public-methods
                     hostRequires=String(),
                     partitions=String(),
                     kickstart=String(),
-                    tasks=String(),
                     match=Class(PositivePattern),
                     dont_match=Class(NegativePattern),
                     waived=Boolean(),
@@ -254,7 +253,6 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
                 ),
                 optional=dict(
                     host_type_regex=Regex(),
-                    tasks=String(),
                     hostRequires=String(),
                     partitions=String(),
                     kickstart=String(),

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -53,9 +53,9 @@ class Object:   # pylint: disable=too-few-public-methods
             setattr(self, member_name, data.get(member_name, None))
 
 
-class Target:  # pylint: disable=too-few-public-methods
+class Target:  # pylint: disable=too-few-public-methods, too-many-arguments
     """Execution target that suite/case patterns match against"""
-    def __init__(self, trees=None, arches=None, sources=None,
+    def __init__(self, trees=None, arches=None, sets=None, sources=None,
                  location_types=None):
         """
         Initialize a target.
@@ -69,6 +69,10 @@ class Target:  # pylint: disable=too-few-public-methods
                             a set thereof. An empty set means all the
                             architectures.
                             None (the default) is equivalent to an empty set.
+            sets:           The name of the set of tests to restrict the run
+                            to, or a set thereof. An empty set means all the
+                            test set names, i.e. no restriction. None (the
+                            default) is equivalent to an empty set.
             sources:        The path to the source file we're covering, or a
                             set thereof. An empty set means all the files.
                             None (the default) is equivalent to an empty set.
@@ -86,6 +90,7 @@ class Target:  # pylint: disable=too-few-public-methods
 
         self.trees = normalize(trees)
         self.arches = normalize(arches)
+        self.sets = normalize(sets)
         self.sources = normalize(sources)
         self.location_types = normalize(location_types)
 
@@ -108,6 +113,7 @@ class Pattern(Object):
                 optional=dict(
                     trees=pattern,
                     arches=pattern,
+                    sets=pattern,
                     sources=pattern,
                     specific_sources=Boolean(),
                     location_types=pattern,
@@ -338,6 +344,7 @@ class Base(Object):     # pylint: disable=too-few-public-methods
                         suites=List(YAMLFile(Class(Suite))),
                         trees=Dict(String()),
                         arches=List(String()),
+                        sets=Dict(String()),
                         host_types=Dict(Class(HostType)),
                         host_type_regex=Regex(),
                         recipesets=Dict(List(String()))
@@ -352,5 +359,7 @@ class Base(Object):     # pylint: disable=too-few-public-methods
             self.trees = {}
         if self.arches is None:
             self.arches = []
+        if self.sets is None:
+            self.sets = {}
         if self.suites is None:
             self.suites = []

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -37,7 +37,6 @@ class Suite:
             assert case in suite.cases
 
         self.description = suite.description
-        self.tasks = suite.tasks
         self.hostRequires = suite.hostRequires  # pylint: disable=invalid-name
         self.partitions = suite.partitions
         self.kickstart = suite.kickstart

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -38,7 +38,6 @@ class Suite:
 
         self.description = suite.description
         self.tasks = suite.tasks
-        self.ignore_panic = suite.ignore_panic
         self.hostRequires = suite.hostRequires  # pylint: disable=invalid-name
         self.partitions = suite.partitions
         self.kickstart = suite.kickstart

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -150,7 +150,7 @@ class Base:     # pylint: disable=too-few-public-methods
                         database.host_type_regex
                     if database.host_types is None or \
                        host_type_regex and \
-                       host_type_regex.match(host_type_name):
+                       host_type_regex.fullmatch(host_type_name):
                         cases.append(case)
                         pool_cases.remove(case)
                 # Add the suite run to the list, if it has cases to run

--- a/tests/assets/db/multihost/two_types/both_cases_both/suite1.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_both/suite1.yaml
@@ -4,7 +4,7 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      host_type_regex: ""
+      host_type_regex: ".*"
       match:
         sources:
           - a

--- a/tests/assets/db/multihost/two_types/both_cases_both/suite2.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_both/suite2.yaml
@@ -4,7 +4,7 @@ maintainers:
 cases:
     - name: case2
       max_duration_seconds: 600
-      host_type_regex: ""
+      host_type_regex: ".*"
       match:
         sources:
           - d


### PR DESCRIPTION
Add support for specifying the available test sets, test membership in
sets, and filtering tests to execute by the sets they belong to.

Do a few drive-by improvements.