### PR TITLE
Accept Netscape-format cookie files

### DIFF
--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -99,10 +99,10 @@ def build(cmds_parser, common_parser):
         parents=[common_parser],
     )
     print_test_cases_parser.add_argument(
-        'patches',
+        'mboxes',
         nargs='*',
         default=[],
-        help='List of patches URLs/paths'
+        help='List of mbox URLs/paths comprising the patch series'
     )
     print_test_cases_parser.add_argument(
         '--pw-cookie',
@@ -176,7 +176,7 @@ def main(args):
             with open(args.output, 'w') as file_handler:
                 file_handler.write(content)
     elif args.action == 'print-test-cases':
-        src_files = get_src_files(args.patches, args.pw_cookie)
+        src_files = get_src_files(args.mboxes, args.pw_cookie)
         target = data.Target(sources=src_files)
         baserun = run.Base(database, target)
         case_name_list = []

--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -51,6 +51,12 @@ def build(cmds_parser, common_parser):
         help='Patchwork session cookie in case a login is required'
     )
     generate_parser.add_argument(
+        '--cookies',
+        metavar='FILE',
+        default=None,
+        help='Cookies to send when downloading patches, Netscape-format file.'
+    )
+    generate_parser.add_argument(
         '-t',
         '--tree',
         required=True,
@@ -110,6 +116,12 @@ def build(cmds_parser, common_parser):
         default=None,
         help='Patchwork session cookie in case a login is required'
     )
+    print_test_cases_parser.add_argument(
+        '--cookies',
+        metavar='FILE',
+        default=None,
+        help='Cookies to send when downloading patches, Netscape-format file.'
+    )
 
 
 def get_src_files(patches, cookies=None):
@@ -138,7 +150,9 @@ def main(args):
     database = data.Base(args.db)
 
     if args.action in ('generate', 'print-test-cases'):
-        cookies = None
+        cookies = cookiejar.MozillaCookieJar()
+        if args.cookies:
+            cookies.load(args.cookies)
         if args.pw_cookie:
             for mbox in args.mboxes:
                 if not misc.is_url(mbox):
@@ -148,7 +162,6 @@ def main(args):
                                           None, False, domain, False, False,
                                           '/', False, False, None, False,
                                           None, None, {})
-                cookies = cookiejar.CookieJar()
                 cookies.set_cookie(cookie)
         src_files = get_src_files(args.mboxes, cookies)
 

--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -134,6 +134,10 @@ def main(args):
     if not data.Base.is_dir_valid(args.db):
         raise Exception("\"{}\" is not a database directory".format(args.db))
     database = data.Base(args.db)
+
+    if args.action in ('generate', 'print-test-cases'):
+        src_files = get_src_files(args.mboxes, args.pw_cookie)
+
     if args.action == 'generate':
         if args.arch not in database.arches:
             raise Exception("Architecture \"{}\" not found".format(args.arch))
@@ -160,7 +164,6 @@ def main(args):
             loc_type = args.type
         assert loc.type_is_valid(loc_type)
 
-        src_files = get_src_files(args.mboxes, args.pw_cookie)
         target = data.Target(trees=args.tree,
                              arches=args.arch,
                              sets=sets,
@@ -176,7 +179,6 @@ def main(args):
             with open(args.output, 'w') as file_handler:
                 file_handler.write(content)
     elif args.action == 'print-test-cases':
-        src_files = get_src_files(args.mboxes, args.pw_cookie)
         target = data.Target(sources=src_files)
         baserun = run.Base(database, target)
         case_name_list = []

--- a/kpet/misc.py
+++ b/kpet/misc.py
@@ -12,7 +12,6 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Miscellaneous routines"""
-import http.cookiejar as cookiejar
 from urllib.parse import urlparse
 import tempfile
 import requests
@@ -27,23 +26,23 @@ def is_url(string):
     return bool(urlparse(string).scheme)
 
 
-def patch2localfile(patches, workdir, session_cookie=None):
-    """Convert all patches in local files"""
+def patch2localfile(patches, workdir, cookies=None):
+    """
+    Convert all patches to local files.
+
+    Args:
+        patches:    A list of patch paths or URLs.
+        workdir:    Directory to place downloaded patches in.
+        cookies:    A jar of cookies to send when downloading patches.
+                    Optional.
+
+    Returns:
+        A list of patch paths.
+    """
     result = []
     for patch in patches:
         if is_url(patch):
-            # Create a Patchwork session cookie if specified
-            cookie_jar = None
-            if session_cookie:
-                domain = patch.rsplit('patch', 1)[0].strip('/').split('/')[-1]
-                cookie = cookiejar.Cookie(0, 'sessionid', session_cookie, None,
-                                          False, domain, False, False, '/',
-                                          False, False, None, False, None,
-                                          None, {})
-                cookie_jar = cookiejar.CookieJar()
-                cookie_jar.set_cookie(cookie)
-
-            response = requests.get(patch, cookies=cookie_jar)
+            response = requests.get(patch, cookies=cookies)
             response.raise_for_status()
             tmpfile = tempfile.mktemp(dir=workdir)
             with open(tmpfile, 'wb') as file_handler:

--- a/tests/test_cmd_run.py
+++ b/tests/test_cmd_run.py
@@ -54,6 +54,7 @@ class CmdRunTest(unittest.TestCase):
         mock_args.db = self.dbdir
         mock_args.no_lint = None
         mock_args.output = None
+        mock_args.cookies = None
         mock_args.pw_cookie = None
         mock_args.description = 'description'
         mock_args.mboxes = []
@@ -69,6 +70,7 @@ class CmdRunTest(unittest.TestCase):
         mock_args.arch = 'arch'
         mock_args.db = '/tmp/igotgoosebutnoshoes'
         mock_args.output = None
+        mock_args.cookies = None
         mock_args.pw_cookie = None
         mock_args.description = 'description'
         mock_args.mboxes = []
@@ -86,6 +88,7 @@ class CmdRunTest(unittest.TestCase):
         mock_args.arch = 'arch'
         mock_args.db = self.dbdir
         mock_args.output = None
+        mock_args.cookies = None
         mock_args.pw_cookie = None
         mock_args.description = 'description'
         mock_args.mboxes = []
@@ -107,6 +110,7 @@ class CmdRunTest(unittest.TestCase):
         mock_args.arch = 'x86_64'
         mock_args.db = self.dbdir
         mock_args.output = None
+        mock_args.cookies = None
         mock_args.pw_cookie = None
         mock_args.description = 'description'
         mock_args.mboxes = []
@@ -124,6 +128,7 @@ class CmdRunTest(unittest.TestCase):
         mock_args.arch = 'foo'
         mock_args.db = self.dbdir
         mock_args.output = None
+        mock_args.cookies = None
         mock_args.pw_cookie = None
         mock_args.description = 'description'
         mock_args.mboxes = []


### PR DESCRIPTION
This adds support for supplying arbitrary cookie files to kpet, for now along with the `--pw-cookie` option, which is to be removed later. This would allow us to switch the CKI pipeline over to simply passing an opaque cookie file around, without making programs like kpet aware of Patchwork or some other system requiring cookie-based authentication.