### PR TITLE
Implement generic pattern

### DIFF
--- a/kpet/schema.py
+++ b/kpet/schema.py
@@ -111,16 +111,17 @@ class Node:
         return data
 
 
-class Choice(Node):
+class Attraction(Node):
     """
     An abstract schema describing an ordered list of schemas, optionally
     intermixed with data conversion functions of undefined purpose. Validates
     against one of the schemas, recognizes as the last schema in the list.
+    Mnemonic: data is attracted to the ultimate schema.
     Cannot resolve data.
     """
     def __init__(self, *args):
         """
-        Initialize a choice schema.
+        Initialize an attraction schema.
 
         Args:
             args:   A list of schemas and data conversion functions.
@@ -158,7 +159,7 @@ class Choice(Node):
         raise NotImplementedError()
 
 
-class Succession(Choice):
+class Succession(Attraction):
     """
     A schema describing a succession of accepted schema versions and the means
     to inherit the legacy data - converter functions. Validates against one of
@@ -195,7 +196,7 @@ class Succession(Choice):
         return last_valid_schema.resolve(data)
 
 
-class Reduction(Choice):
+class Reduction(Attraction):
     """
     A schema describing a general schema and a choice of specific schemas for
     the same data, along with the means to convert the data from each of the

--- a/kpet/schema.py
+++ b/kpet/schema.py
@@ -279,6 +279,12 @@ class Reduction(Attraction):
         return self.schemas_and_converters[-1].resolve(data)
 
 
+class Null(Node):
+    """Null schema"""
+    def __init__(self):
+        super().__init__(type(None))
+
+
 class String(Node):
     """String schema"""
     def __init__(self):

--- a/kpet/schema.py
+++ b/kpet/schema.py
@@ -22,7 +22,7 @@ import yaml
 
 # The type returned by re.compile(). Different between Python 2 and 3
 # TODO Switch to just using re.Pattern once upgraded to Python 3.7 or later
-_RE = type(re.compile(""))
+RE = type(re.compile(""))
 
 
 def _get_re_error_type():
@@ -274,7 +274,7 @@ class Regex(String):
             raise Invalid("Invalid regular expression")
 
     def recognize(self):
-        return Node(_RE)
+        return Node(RE)
 
     def resolve(self, data):
         self.validate(data)

--- a/tests/assets/db/general/suites/fs/index.yaml
+++ b/tests/assets/db/general/suites/fs/index.yaml
@@ -6,15 +6,17 @@ cases:
     -   hostRequires: suites/fs/hostrequires.xml
         name: fs/ext4
         max_duration_seconds: 600
-        match:
+        pattern:
           sources:
-            - ^fs/ext4/.*
-            - ^fs/jbd2/.*
+            or:
+              - ^fs/ext4/.*
+              - ^fs/jbd2/.*
 
     -   name: fs/xfs
         partitions: suites/fs/partitions.xml
         max_duration_seconds: 600
-        match:
+        pattern:
           sources:
-            - ^fs/xfs/.*
-            - ^fs/[^/]*[ch]
+            or:
+              - ^fs/xfs/.*
+              - ^fs/[^/]*[ch]

--- a/tests/assets/db/match/arches/no_patterns/suite.yaml
+++ b/tests/assets/db/match/arches/no_patterns/suite.yaml
@@ -4,5 +4,6 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
-          arches: []
+      pattern:
+          arches:
+              or: []

--- a/tests/assets/db/match/arches/one_pattern/suite.yaml
+++ b/tests/assets/db/match/arches/one_pattern/suite.yaml
@@ -4,5 +4,5 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
           arches: arch

--- a/tests/assets/db/match/arches/two_patterns/suite.yaml
+++ b/tests/assets/db/match/arches/two_patterns/suite.yaml
@@ -4,7 +4,8 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
           arches:
-              - arch
-              - other_arch
+              or:
+                  - arch
+                  - other_arch

--- a/tests/assets/db/match/location_types/no_patterns/suite.yaml
+++ b/tests/assets/db/match/location_types/no_patterns/suite.yaml
@@ -4,5 +4,6 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
-          location_types: []
+      pattern:
+          location_types: 
+            or: []

--- a/tests/assets/db/match/location_types/one_pattern/suite.yaml
+++ b/tests/assets/db/match/location_types/one_pattern/suite.yaml
@@ -4,25 +4,25 @@ maintainers:
 cases:
     - name: tarball-path
       max_duration_seconds: 600
-      match:
+      pattern:
           location_types: tarball-path
     - name: rpm-path
       max_duration_seconds: 600
-      match:
+      pattern:
           location_types: rpm-path
     - name: repo-path
       max_duration_seconds: 600
-      match:
+      pattern:
           location_types: repo-path
     - name: tarball-url
       max_duration_seconds: 600
-      match:
+      pattern:
           location_types: tarball-url
     - name: rpm-url
       max_duration_seconds: 600
-      match:
+      pattern:
           location_types: rpm-url
     - name: repo-url
       max_duration_seconds: 600
-      match:
+      pattern:
           location_types: repo-url

--- a/tests/assets/db/match/location_types/two_patterns/suite.yaml
+++ b/tests/assets/db/match/location_types/two_patterns/suite.yaml
@@ -4,19 +4,22 @@ maintainers:
 cases:
     - name: tarball
       max_duration_seconds: 600
-      match:
+      pattern:
           location_types:
-              - tarball-path
-              - tarball-url
+              or:
+                  - tarball-path
+                  - tarball-url
     - name: rpm
       max_duration_seconds: 600
-      match:
+      pattern:
           location_types:
-              - rpm-path
-              - rpm-url
+              or:
+                  - rpm-path
+                  - rpm-url
     - name: repo
       max_duration_seconds: 600
-      match:
+      pattern:
           location_types:
-              - repo-path
-              - repo-url
+              or:
+                  - repo-path
+                  - repo-url

--- a/tests/assets/db/match/sources/one_case/one_pattern/suite.yaml
+++ b/tests/assets/db/match/sources/one_case/one_pattern/suite.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/match/sources/one_case/two_patterns/suite.yaml
+++ b/tests/assets/db/match/sources/one_case/two_patterns/suite.yaml
@@ -4,7 +4,8 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - a
-          - d
+          or:
+              - a
+              - d

--- a/tests/assets/db/match/sources/specific/case/suite1.yaml
+++ b/tests/assets/db/match/sources/specific/case/suite1.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
-          specific_sources: true
+      pattern:
+          not:
+              sources: null
           sources: a

--- a/tests/assets/db/match/sources/specific/case/suite2.yaml
+++ b/tests/assets/db/match/sources/specific/case/suite2.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case2
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/match/sources/specific/suite/suite1.yaml
+++ b/tests/assets/db/match/sources/specific/suite/suite1.yaml
@@ -1,10 +1,11 @@
 description: suite1
 maintainers:
   - maint1
-match:
-    specific_sources: true
+pattern:
+    not:
+        sources: null
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
           sources: a

--- a/tests/assets/db/match/sources/specific/suite/suite2.yaml
+++ b/tests/assets/db/match/sources/specific/suite/suite2.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case2
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/match/sources/two_cases/suite.yaml
+++ b/tests/assets/db/match/sources/two_cases/suite.yaml
@@ -4,11 +4,13 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a
     - name: case2
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/match/sources/two_suites/suite1.yaml
+++ b/tests/assets/db/match/sources/two_suites/suite1.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/match/sources/two_suites/suite2.yaml
+++ b/tests/assets/db/match/sources/two_suites/suite2.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case2
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/match/trees/no_patterns/suite.yaml
+++ b/tests/assets/db/match/trees/no_patterns/suite.yaml
@@ -4,5 +4,6 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
-          trees: []
+      pattern:
+          trees:
+              or: []

--- a/tests/assets/db/match/trees/one_pattern/suite.yaml
+++ b/tests/assets/db/match/trees/one_pattern/suite.yaml
@@ -4,5 +4,5 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
           trees: tree

--- a/tests/assets/db/match/trees/two_patterns/suite.yaml
+++ b/tests/assets/db/match/trees/two_patterns/suite.yaml
@@ -4,7 +4,8 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
           trees:
-              - tree
-              - other_tree
+              or:
+                  - tree
+                  - other_tree

--- a/tests/assets/db/multihost/no_types/db_regex/suite1.yaml
+++ b/tests/assets/db/multihost/no_types/db_regex/suite1.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/multihost/no_types/db_regex/suite2.yaml
+++ b/tests/assets/db/multihost/no_types/db_regex/suite2.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case2
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/multihost/no_types/no_regex/two_suites/suite1.yaml
+++ b/tests/assets/db/multihost/no_types/no_regex/two_suites/suite1.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/multihost/no_types/no_regex/two_suites/suite2.yaml
+++ b/tests/assets/db/multihost/no_types/no_regex/two_suites/suite2.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case2
       max_duration_seconds: 600
-      match:
-        sources:
-          - d
+      pattern:
+          sources:
+              or:
+                  - d

--- a/tests/assets/db/multihost/one_type/case_regex/suite1.yaml
+++ b/tests/assets/db/multihost/one_type/case_regex/suite1.yaml
@@ -5,6 +5,7 @@ cases:
     - name: case1
       max_duration_seconds: 600
       host_type_regex: normal
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/multihost/one_type/case_regex/suite2.yaml
+++ b/tests/assets/db/multihost/one_type/case_regex/suite2.yaml
@@ -5,6 +5,7 @@ cases:
     - name: case2
       max_duration_seconds: 600
       host_type_regex: not_normal
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/multihost/one_type/db_regex/suite1.yaml
+++ b/tests/assets/db/multihost/one_type/db_regex/suite1.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/multihost/one_type/db_regex/suite2.yaml
+++ b/tests/assets/db/multihost/one_type/db_regex/suite2.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case2
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/multihost/one_type/no_regex/two_suites/suite1.yaml
+++ b/tests/assets/db/multihost/one_type/no_regex/two_suites/suite1.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/multihost/one_type/no_regex/two_suites/suite2.yaml
+++ b/tests/assets/db/multihost/one_type/no_regex/two_suites/suite2.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case2
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/multihost/one_type/suite_regex/suite1.yaml
+++ b/tests/assets/db/multihost/one_type/suite_regex/suite1.yaml
@@ -5,6 +5,7 @@ host_type_regex: normal
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/multihost/one_type/suite_regex/suite2.yaml
+++ b/tests/assets/db/multihost/one_type/suite_regex/suite2.yaml
@@ -5,6 +5,7 @@ host_type_regex: not_normal
 cases:
     - name: case2
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/multihost/one_type/wrong_regex/suite1.yaml
+++ b/tests/assets/db/multihost/one_type/wrong_regex/suite1.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case1
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/multihost/one_type/wrong_regex/suite2.yaml
+++ b/tests/assets/db/multihost/one_type/wrong_regex/suite2.yaml
@@ -4,6 +4,7 @@ maintainers:
 cases:
     - name: case2
       max_duration_seconds: 600
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/multihost/two_types/both_cases_both/suite1.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_both/suite1.yaml
@@ -5,6 +5,7 @@ cases:
     - name: case1
       max_duration_seconds: 600
       host_type_regex: ".*"
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/multihost/two_types/both_cases_both/suite2.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_both/suite2.yaml
@@ -5,6 +5,7 @@ cases:
     - name: case2
       max_duration_seconds: 600
       host_type_regex: ".*"
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/multihost/two_types/both_cases_first/suite1.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_first/suite1.yaml
@@ -5,6 +5,7 @@ cases:
     - name: case1
       max_duration_seconds: 600
       host_type_regex: a
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/multihost/two_types/both_cases_first/suite2.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_first/suite2.yaml
@@ -5,6 +5,7 @@ cases:
     - name: case2
       max_duration_seconds: 600
       host_type_regex: a
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/multihost/two_types/both_cases_second/suite1.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_second/suite1.yaml
@@ -5,6 +5,7 @@ cases:
     - name: case1
       max_duration_seconds: 600
       host_type_regex: b
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/multihost/two_types/both_cases_second/suite2.yaml
+++ b/tests/assets/db/multihost/two_types/both_cases_second/suite2.yaml
@@ -5,6 +5,7 @@ cases:
     - name: case2
       max_duration_seconds: 600
       host_type_regex: b
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d

--- a/tests/assets/db/multihost/two_types/one_case_each/suite1.yaml
+++ b/tests/assets/db/multihost/two_types/one_case_each/suite1.yaml
@@ -5,6 +5,7 @@ cases:
     - name: case1
       max_duration_seconds: 600
       host_type_regex: a
-      match:
+      pattern:
         sources:
-          - a
+          or:
+              - a

--- a/tests/assets/db/multihost/two_types/one_case_each/suite2.yaml
+++ b/tests/assets/db/multihost/two_types/one_case_each/suite2.yaml
@@ -5,6 +5,7 @@ cases:
     - name: case2
       max_duration_seconds: 600
       host_type_regex: b
-      match:
+      pattern:
         sources:
-          - d
+          or:
+              - d


### PR DESCRIPTION
This implements generic test condition patterns, which are to replace the use of `match` and `dont_match`. Required by kpet-db MR 251, which also contains plenty of new pattern usage examples and some documentation.