### PR TITLE
Support selecting build components

### DIFF
--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -16,7 +16,7 @@ import argparse
 import os
 import sys
 import logging
-from kpet import cmd_run, cmd_tree, cmd_arch, cmd_set
+from kpet import cmd_run, cmd_tree, cmd_arch, cmd_component, cmd_set
 
 
 def exec_command(args, commands):
@@ -53,6 +53,7 @@ def main(args=None):
     cmd_run.build(cmds_parser, common_parser)
     cmd_tree.build(cmds_parser, common_parser)
     cmd_arch.build(cmds_parser, common_parser)
+    cmd_component.build(cmds_parser, common_parser)
     cmd_set.build(cmds_parser, common_parser)
 
     args = parser.parse_args(args)
@@ -61,6 +62,7 @@ def main(args=None):
         'run': [cmd_run.main, args],
         'tree': [cmd_tree.main, args],
         'arch': [cmd_arch.main, args],
+        'component': [cmd_component.main, args],
         'set': [cmd_set.main, args],
     }
     exec_command(args, commands)

--- a/kpet/cmd_component.py
+++ b/kpet/cmd_component.py
@@ -1,0 +1,44 @@
+# Copyright (c) 2018 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""The "component" command"""
+from kpet import misc, data, cmd_misc
+
+
+def build(cmds_parser, common_parser):
+    """Build the argument parser for the component command"""
+    _, action_subparser = cmd_misc.build(
+        cmds_parser,
+        common_parser,
+        "component",
+        help='Build component, default action "list".',
+    )
+    action_subparser.add_parser(
+        "list",
+        help='List recognized build components.',
+        parents=[common_parser],
+    )
+
+
+def main(args):
+    """Main function for the `component` command"""
+    if not data.Base.is_dir_valid(args.db):
+        raise Exception("\"{}\" is not a database directory".format(args.db))
+    database = data.Base(args.db)
+    if args.action == 'list':
+        max_name_length = max((len(k) for k in database.components), default=0)
+        for name, description in sorted(database.components.items(),
+                                        key=lambda i: i[0]):
+            print(f"{name: <{max_name_length}} {description}")
+    else:
+        misc.raise_action_not_found(args.action, args.command)

--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -53,6 +53,14 @@ def build_target(parser):
         'See "kpet arch list" for supported architectures.'
     )
     parser.add_argument(
+        '-c',
+        '--components',
+        metavar='REGEX',
+        help='A regular expression matching extra components included ' +
+        'into the kernel build. ' +
+        'See "kpet component list" for recognized components.'
+    )
+    parser.add_argument(
         '-s',
         '--sets',
         metavar='REGEX',
@@ -139,6 +147,7 @@ def get_src_files(patches, cookies=None):
         shutil.rmtree(tmpdir)
 
 
+# pylint: disable=too-many-branches
 def main_create_baserun(args, database):
     """
     Generate test execution data for specified test database and command-line
@@ -169,6 +178,14 @@ def main_create_baserun(args, database):
         raise Exception("Architecture \"{}\" not found".format(args.arch))
     if args.tree not in database.trees:
         raise Exception("Tree \"{}\" not found".format(args.tree))
+    if args.components is None:
+        components = set()
+    else:
+        components = set(x for x in database.components
+                         if re.fullmatch(args.components, x))
+        if not components:
+            raise Exception("No components matched specified regular " +
+                            "expression: {}".format(args.components))
     if args.sets is None:
         sets = set()
     else:
@@ -192,6 +209,7 @@ def main_create_baserun(args, database):
 
     target = data.Target(trees=args.tree,
                          arches=args.arch,
+                         components=components,
                          sets=sets,
                          sources=src_files,
                          location_types=loc_type)

--- a/kpet/cmd_set.py
+++ b/kpet/cmd_set.py
@@ -36,7 +36,7 @@ def main(args):
         raise Exception("\"{}\" is not a database directory".format(args.db))
     database = data.Base(args.db)
     if args.action == 'list':
-        max_name_length = max(len(k) for k in database.sets)
+        max_name_length = max((len(k) for k in database.sets), default=0)
         for name, description in sorted(database.sets.items(),
                                         key=lambda i: i[0]):
             print(f"{name: <{max_name_length}} {description}")

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -56,8 +56,8 @@ class Object:   # pylint: disable=too-few-public-methods
 
 class Target:  # pylint: disable=too-few-public-methods, too-many-arguments
     """Execution target that suite/case patterns match against"""
-    def __init__(self, trees=None, arches=None, sets=None, sources=None,
-                 location_types=None):
+    def __init__(self, trees=None, arches=None, components=None, sets=None,
+                 sources=None, location_types=None):
         """
         Initialize a target.
 
@@ -70,6 +70,10 @@ class Target:  # pylint: disable=too-few-public-methods, too-many-arguments
                             a set thereof. An empty set means all the
                             architectures.
                             None (the default) is equivalent to an empty set.
+            components:     The name of an extra component included into the
+                            tested kernel build, or a set thereof. An empty
+                            set means no extra components. None (the default)
+                            is equivalent to an empty set.
             sets:           The name of the set of tests to restrict the run
                             to, or a set thereof. An empty set means all the
                             test set names, i.e. no restriction. None (the
@@ -91,8 +95,10 @@ class Target:  # pylint: disable=too-few-public-methods, too-many-arguments
 
         self.trees = normalize(trees)
         self.arches = normalize(arches)
+        self.components = normalize(components)
         self.sets = normalize(sets)
         self.sources = normalize(sources)
+        # TODO: Remove once kpet-db switches to components
         self.location_types = normalize(location_types)
 
 
@@ -100,7 +106,9 @@ class Pattern(Object):  # pylint: disable=too-few-public-methods
     """Execution target pattern"""
 
     # Target field qualifiers
-    qualifiers = {"trees", "arches", "sets", "sources", "location_types"}
+    qualifiers = {"trees", "arches", "components", "sets", "sources",
+                  # TODO: Remove once kpet-db switches to components
+                  "location_types"}
 
     """An execution target pattern"""
     def __init__(self, data):
@@ -368,6 +376,7 @@ class Base(Object):     # pylint: disable=too-few-public-methods
                         suites=List(YAMLFile(Class(Suite))),
                         trees=Dict(String()),
                         arches=List(String()),
+                        components=Dict(String()),
                         sets=Dict(String()),
                         host_types=Dict(Class(HostType)),
                         host_type_regex=Regex(),
@@ -383,6 +392,8 @@ class Base(Object):     # pylint: disable=too-few-public-methods
             self.trees = {}
         if self.arches is None:
             self.arches = []
+        if self.components is None:
+            self.components = {}
         if self.sets is None:
             self.sets = {}
         if self.suites is None:

--- a/tests/test_cmd_run.py
+++ b/tests/test_cmd_run.py
@@ -85,7 +85,9 @@ class CmdRunTest(unittest.TestCase):
         mock_args.action = 'print-test-cases'
         mock_args.tree = 'rhel7'
         mock_args.kernel = 'kernel'
-        mock_args.arch = 'arch'
+        mock_args.arch = 'x86_64'
+        mock_args.sets = None
+        mock_args.type = 'auto'
         mock_args.db = self.dbdir
         mock_args.output = None
         mock_args.cookies = None

--- a/tests/test_cmd_run.py
+++ b/tests/test_cmd_run.py
@@ -86,6 +86,7 @@ class CmdRunTest(unittest.TestCase):
         mock_args.tree = 'rhel7'
         mock_args.kernel = 'kernel'
         mock_args.arch = 'x86_64'
+        mock_args.components = None
         mock_args.sets = None
         mock_args.type = 'auto'
         mock_args.db = self.dbdir


### PR DESCRIPTION
This adds support for listing and selecting extra components present in the tested kernel build, such as debug symbols, or tools. This would allow us to make tests depend on those components and only run when they're present.