### PR TITLE
print help when action is not specified

### DIFF
--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -17,6 +17,7 @@ import os
 import sys
 import logging
 from kpet import cmd_run, cmd_tree, cmd_arch, cmd_component, cmd_set
+from kpet import misc
 
 
 def exec_command(args, commands):
@@ -65,4 +66,9 @@ def main(args=None):
         'component': [cmd_component.main, args],
         'set': [cmd_set.main, args],
     }
-    exec_command(args, commands)
+    try:
+        exec_command(args, commands)
+    except misc.ActionNotFound:
+        logging.error('No action specified')
+        parser.print_help()
+        parser.print_help(file=sys.stderr)


### PR DESCRIPTION
This implements FASTMOVING-929, see this ticket for details.
Whenever action is not specified (e.g. only "kpet set/run/..." is called
without params), we log.error explain the problem and print parser help.

Signed-off-by: Jakub Racek <jracek@redhat.com>