### PR TITLE
remove tasks from host type

### DIFF
--- a/kpet/data.py
+++ b/kpet/data.py
@@ -335,7 +335,6 @@ class HostType(Object):     # pylint: disable=too-few-public-methods
                 hostname=String(),
                 partitions=String(),
                 kickstart=String(),
-                tasks=String(),
             )),
             data
         )

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -69,7 +69,6 @@ class Host:
         self.hostRequires = type.hostRequires
         self.partitions = type.partitions
         self.kickstart = type.kickstart
-        self.tasks = type.tasks
         self.suites = suites
 
         self.name = name


### PR DESCRIPTION
This implements FASTMOVING-826.

Adding tasks through host type is no longer used, so let's remove it.

Signed-off-by: Jakub Racek <jracek@redhat.com>