### PR TITLE
Omit backtraces by default

### DIFF
--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -44,6 +44,8 @@ def main(args=None):
     common_parser = argparse.ArgumentParser(add_help=False)
     common_parser.add_argument('--verbose', '-v', action='count')
     parser = argparse.ArgumentParser(description=description)
+    parser.add_argument('-d', '--debug', action='store_true',
+                        help='Enable debug (backtrace) output on error')
     parser.add_argument(
         '--db',
         help='Location of database of kernel trees and tests, default "."',
@@ -58,6 +60,10 @@ def main(args=None):
     cmd_set.build(cmds_parser, common_parser)
 
     args = parser.parse_args(args)
+
+    if not args.debug:
+        sys.tracebacklimit = 0
+
     commands = {
         'help': [parser.print_help],
         'run': [cmd_run.main, args],


### PR DESCRIPTION
Backtrace output is now omited unless "-d" or "--debug" is specified.
Example:
- With debug:
`1560851081.299585:ERROR:While executing command "run"`
`Traceback (most recent call last):`
`  File "/home/okinst/.local/bin/kpet", line 11, in <module>`
`    load_entry_point('kpet', 'console_scripts', 'kpet')()`
`  File "/home/okinst/projects/kpet/kpet/__init__.py", line 76, in main`
`    exec_command(args, commands)`
`  File "/home/okinst/projects/kpet/kpet/__init__.py", line 31, in exec_command`
`    command[0](*command[1:])`
`  File "/home/okinst/projects/kpet/kpet/cmd_run.py", line 256, in main`
`    raise Exception("\"{}\" is not a database directory".format(args.db))`
`Exception: ".../kpet-db" is not a database directory`
- Without debug:
`1560851172.384047:ERROR:While executing command "run"`
`Exception: ".../kpet-db" is not a database directory`