### PR TITLE
Distinguish wildcards and empty sets in targets

### DIFF
--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -173,7 +173,10 @@ def main_create_baserun(args, database):
                                       '/', False, False, None, False,
                                       None, None, {})
             cookies.set_cookie(cookie)
-    src_files = get_src_files(args.mboxes, cookies)
+    if args.mboxes:
+        src_files = get_src_files(args.mboxes, cookies)
+    else:
+        src_files = None
     if args.arch not in database.arches:
         raise Exception("Architecture \"{}\" not found".format(args.arch))
     if args.tree not in database.trees:
@@ -184,7 +187,7 @@ def main_create_baserun(args, database):
         components = set(x for x in database.components
                          if re.fullmatch(args.components, x))
     if args.sets is None:
-        sets = set()
+        sets = None
     else:
         sets = set(x for x in database.sets if re.fullmatch(args.sets, x))
         if not sets:

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -63,33 +63,26 @@ class Target:  # pylint: disable=too-few-public-methods, too-many-arguments
 
         Args:
             trees:          The name of the kernel tree we're executing
-                            against, or a set thereof. An empty set means all
-                            the trees.
-                            None (the default) is equivalent to an empty set.
+                            against, or a set thereof.
+                            None (the default) means all the trees.
             arches:         The name of the architecture we're executing on or
-                            a set thereof. An empty set means all the
-                            architectures.
-                            None (the default) is equivalent to an empty set.
+                            a set thereof.
+                            None (the default) means all the architectures.
             components:     The name of an extra component included into the
-                            tested kernel build, or a set thereof. An empty
-                            set means no extra components. None (the default)
-                            is equivalent to an empty set.
+                            tested kernel build, or a set thereof.
+                            None (the default) means all the extra components.
             sets:           The name of the set of tests to restrict the run
-                            to, or a set thereof. An empty set means all the
-                            test set names, i.e. no restriction. None (the
-                            default) is equivalent to an empty set.
+                            to, or a set thereof. None (the default) means all
+                            the sets (i.e. no restriction).
             sources:        The path to the source file we're covering, or a
-                            set thereof. An empty set means all the files.
-                            None (the default) is equivalent to an empty set.
+                            set thereof. None (the default) means all the
+                            files.
             location_types: The type of the location of the kernel we're
                             testing (a member of loc.TYPE_SET), or a set
-                            thereof. An empty set means all the types.
-                            None (the default) is equivalent to an empty set.
+                            thereof. None (the default) means all the types.
         """
         def normalize(arg):
-            if arg is None:
-                return set()
-            if isinstance(arg, set):
+            if arg is None or isinstance(arg, set):
                 return arg
             return {arg}
 
@@ -210,16 +203,19 @@ class Pattern(Object):  # pylint: disable=too-few-public-methods
                     result |= sub_result
         elif isinstance(node, RE):
             assert qualifier is not None, "Qualifier not specified"
-            value_set = getattr(target, qualifier)
-            for value in value_set:
-                if node.fullmatch(value):
-                    result = True
-                    break
+            value_set_or_none = getattr(target, qualifier)
+            if value_set_or_none is None:
+                result = True
             else:
-                result = (value_set == set())
+                for value in value_set_or_none:
+                    if node.fullmatch(value):
+                        result = True
+                        break
+                else:
+                    result = False
         elif node is None:
             assert qualifier is not None, "Qualifier not specified"
-            result = getattr(target, qualifier) == set()
+            result = getattr(target, qualifier) is None
         else:
             assert False, "Unknown node type: " + type(node).__name__
 

--- a/tests/test_cmd_run.py
+++ b/tests/test_cmd_run.py
@@ -33,7 +33,7 @@ class CmdRunTest(unittest.TestCase):
         Check the success case.
         """
         database = data.Base(self.dbdir)
-        target = data.Target(arches='x86_64', trees='rhel7', sources=set())
+        target = data.Target(arches='x86_64', trees='rhel7', sources=None)
         baserun = run.Base(database, target)
         content = baserun.generate(description='Foo', kernel_location='bar',
                                    lint=True)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -94,33 +94,33 @@ class DataPatternTest(unittest.TestCase):
         """Check empty patterns match anything"""
         self.assertMatch({})
 
-        self.assertMatch({}, sources=set())
+        self.assertMatch({}, sources=None)
         self.assertMatch({}, sources={"a"})
 
-        self.assertMatch({}, trees=set())
+        self.assertMatch({}, trees=None)
         self.assertMatch({}, trees={"a"})
 
-        self.assertMatch({}, arches=set())
+        self.assertMatch({}, arches=None)
         self.assertMatch({}, arches={"a"})
 
-        self.assertMatch({}, sources=set(), trees=set())
-        self.assertMatch({}, sources=set(), trees={"a"})
-        self.assertMatch({}, sources={"a"}, trees=set())
+        self.assertMatch({}, sources=None, trees=None)
+        self.assertMatch({}, sources=None, trees={"a"})
+        self.assertMatch({}, sources={"a"}, trees=None)
         self.assertMatch({}, sources={"a"}, trees={"a"})
 
     def test_specific_sources(self):
         """Check patterns match specific/all sources correctly"""
         self.assertMismatch({"not": dict(sources=None)},
-                            sources=set())
+                            sources=None)
         self.assertMismatch({"not": dict(sources=None), "sources": "a"},
-                            sources=set())
+                            sources=None)
 
         self.assertMismatch(dict(sources=None), sources={"a"})
         self.assertMismatch(dict(sources=[None, "a"]), sources={"a"})
         self.assertMismatch(dict(sources=[None, "b"]), sources={"a"})
 
-        self.assertMatch(dict(sources=None), sources=set())
-        self.assertMatch(dict(sources=[None, "a"]), sources=set())
+        self.assertMatch(dict(sources=None), sources=None)
+        self.assertMatch(dict(sources=[None, "a"]), sources=None)
 
         self.assertMatch({"not": dict(sources=None)},
                          sources={"a"})
@@ -132,11 +132,11 @@ class DataPatternTest(unittest.TestCase):
     def test_two_params(self):
         """Check two-parameter patterns match correctly"""
         self.assertMatch(dict(sources="a", trees="A"),
-                         sources=set(), trees=set())
+                         sources=None, trees=None)
         self.assertMatch(dict(sources="a", trees="A"),
-                         sources=set(), trees={"A"})
+                         sources=None, trees={"A"})
         self.assertMatch(dict(sources="a", trees="A"),
-                         sources={"a"}, trees=set())
+                         sources={"a"}, trees=None)
         self.assertMatch(dict(sources="a", trees="A"),
                          sources={"a"}, trees={"A"})
 


### PR DESCRIPTION
Instead of considering both None and empty sets as wildcard values when
used as the various components of targets (kpet.data.Target), consider
only None as the wildcard value, and allow specifying empty sets as
target components.

This would allow expressing the (default) situation of no extra build
components specified to kpet. Otherwise the default situation could only
be all extra components.