### PR TITLE
Add regex object filtering

### DIFF
--- a/kpet/cmd_arch.py
+++ b/kpet/cmd_arch.py
@@ -12,6 +12,8 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """The "arch" command"""
+import re
+
 from kpet import misc, data, cmd_misc
 
 
@@ -23,11 +25,13 @@ def build(cmds_parser, common_parser):
         "arch",
         help='Architecture to test on, default action "list"',
     )
-    action_subparser.add_parser(
+    list_parser = action_subparser.add_parser(
         "list",
         help='Output a list of known architecture names',
         parents=[common_parser],
     )
+    list_parser.add_argument('regex', nargs='?', default=None,
+                             help='Optional. Use this to filter results.')
 
 
 def main(args):
@@ -36,7 +40,10 @@ def main(args):
         raise Exception("\"{}\" is not a database directory".format(args.db))
     database = data.Base(args.db)
     if args.action == 'list':
+        regex = re.compile(args.regex) if args.regex else None
         for arch in sorted(database.arches):
-            print(arch)
+            # filter using regex; if it's not set, print all
+            if not regex or regex.match(arch):
+                print(arch)
     else:
         misc.raise_action_not_found(args.action, args.command)

--- a/kpet/cmd_component.py
+++ b/kpet/cmd_component.py
@@ -12,6 +12,8 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """The "component" command"""
+import re
+
 from kpet import misc, data, cmd_misc
 
 
@@ -23,11 +25,13 @@ def build(cmds_parser, common_parser):
         "component",
         help='Build component, default action "list".',
     )
-    action_subparser.add_parser(
+    list_parser = action_subparser.add_parser(
         "list",
         help='List recognized build components.',
         parents=[common_parser],
     )
+    list_parser.add_argument('regex', nargs='?', default=None,
+                             help='Optional. Use this to filter results.')
 
 
 def main(args):
@@ -36,9 +40,11 @@ def main(args):
         raise Exception("\"{}\" is not a database directory".format(args.db))
     database = data.Base(args.db)
     if args.action == 'list':
+        regex = re.compile(args.regex) if args.regex else None
         max_name_length = max((len(k) for k in database.components), default=0)
         for name, description in sorted(database.components.items(),
                                         key=lambda i: i[0]):
-            print(f"{name: <{max_name_length}} {description}")
+            if not regex or regex.match(name):
+                print(f"{name: <{max_name_length}} {description}")
     else:
         misc.raise_action_not_found(args.action, args.command)

--- a/kpet/cmd_set.py
+++ b/kpet/cmd_set.py
@@ -12,6 +12,8 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """The "set" command"""
+import re
+
 from kpet import misc, data, cmd_misc
 
 
@@ -23,11 +25,13 @@ def build(cmds_parser, common_parser):
         "set",
         help='Test set, default action "list".',
     )
-    action_subparser.add_parser(
+    list_parser = action_subparser.add_parser(
         "list",
         help='List available test sets.',
         parents=[common_parser],
     )
+    list_parser.add_argument('regex', nargs='?', default=None,
+                             help='Optional. Use this to filter results.')
 
 
 def main(args):
@@ -36,9 +40,11 @@ def main(args):
         raise Exception("\"{}\" is not a database directory".format(args.db))
     database = data.Base(args.db)
     if args.action == 'list':
+        regex = re.compile(args.regex) if args.regex else None
         max_name_length = max((len(k) for k in database.sets), default=0)
         for name, description in sorted(database.sets.items(),
                                         key=lambda i: i[0]):
-            print(f"{name: <{max_name_length}} {description}")
+            if not regex or regex.match(name):
+                print(f"{name: <{max_name_length}} {description}")
     else:
         misc.raise_action_not_found(args.action, args.command)

--- a/kpet/cmd_tree.py
+++ b/kpet/cmd_tree.py
@@ -12,6 +12,8 @@
 # this program; if not, write to the Free Software Foundation, Inc., 51
 # Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """The "tree" command"""
+import re
+
 from kpet import misc, data, cmd_misc
 
 
@@ -23,11 +25,13 @@ def build(cmds_parser, common_parser):
         "tree",
         help='Kernel tree, default action "list".',
     )
-    action_subparser.add_parser(
+    list_parser = action_subparser.add_parser(
         "list",
         help='List available kernel trees.',
         parents=[common_parser],
     )
+    list_parser.add_argument('regex', nargs='?', default=None,
+                             help='Optional. Use this to filter results.')
 
 
 def main(args):
@@ -36,7 +40,9 @@ def main(args):
         raise Exception("\"{}\" is not a database directory".format(args.db))
     database = data.Base(args.db)
     if args.action == 'list':
+        regex = re.compile(args.regex) if args.regex else None
         for tree in sorted(database.trees.keys()):
-            print(tree)
+            if not regex or regex.match(tree):
+                print(tree)
     else:
         misc.raise_action_not_found(args.action, args.command)

--- a/tests/test_cmd_tree.py
+++ b/tests/test_cmd_tree.py
@@ -28,6 +28,7 @@ class CmdTreeTest(unittest.TestCase):
         dbdir = os.path.join(os.path.dirname(__file__), 'assets/db/general')
         mock_args = mock.Mock()
         mock_args.db = dbdir
+        mock_args.regex = None
         self.assertRaises(misc.ActionNotFound, cmd_tree.main, mock_args)
         mock_args.action = 'list'
         with mock.patch('sys.stdout') as mock_stdout:


### PR DESCRIPTION
This patch series implements FASTMOVING-932.
    
If no positional argument is used, all objects are printed. If regex is
used, only objects that match it are printed.