### PR TITLE
Support specifying tree architectures

### DIFF
--- a/kpet/cmd_arch.py
+++ b/kpet/cmd_arch.py
@@ -40,10 +40,10 @@ def main(args):
         raise Exception("\"{}\" is not a database directory".format(args.db))
     database = data.Base(args.db)
     if args.action == 'list':
-        regex = re.compile(args.regex) if args.regex else None
+        regex = re.compile(args.regex or ".*")
         for arch in sorted(database.arches):
             # filter using regex; if it's not set, print all
-            if not regex or regex.fullmatch(arch):
+            if regex.fullmatch(arch):
                 print(arch)
     else:
         misc.raise_action_not_found(args.action, args.command)

--- a/kpet/cmd_arch.py
+++ b/kpet/cmd_arch.py
@@ -43,7 +43,7 @@ def main(args):
         regex = re.compile(args.regex) if args.regex else None
         for arch in sorted(database.arches):
             # filter using regex; if it's not set, print all
-            if not regex or regex.match(arch):
+            if not regex or regex.fullmatch(arch):
                 print(arch)
     else:
         misc.raise_action_not_found(args.action, args.command)

--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -138,10 +138,15 @@ def main_create_baserun(args, database):
                                                       cookies)
     else:
         src_set = None
-    if args.arch is not None and args.arch not in database.arches:
-        raise Exception("Architecture \"{}\" not found".format(args.arch))
     if args.tree is not None and args.tree not in database.trees:
         raise Exception("Tree \"{}\" not found".format(args.tree))
+    if args.arch is not None:
+        if args.arch not in database.arches:
+            raise Exception("Architecture \"{}\" not found".format(args.arch))
+        if args.tree is not None and\
+           args.arch not in database.trees[args.tree]['arches']:
+            raise Exception("Arch \"{}\" not supported by tree \"{}\"".format(
+                args.arch, args.tree))
     if args.components is None:
         components = set()
     else:

--- a/kpet/cmd_tree.py
+++ b/kpet/cmd_tree.py
@@ -40,9 +40,9 @@ def main(args):
         raise Exception("\"{}\" is not a database directory".format(args.db))
     database = data.Base(args.db)
     if args.action == 'list':
-        regex = re.compile(args.regex) if args.regex else None
+        regex = re.compile(args.regex or ".*")
         for tree in sorted(database.trees.keys()):
-            if not regex or regex.fullmatch(tree):
+            if regex.fullmatch(tree):
                 print(tree)
     else:
         misc.raise_action_not_found(args.action, args.command)

--- a/kpet/cmd_tree.py
+++ b/kpet/cmd_tree.py
@@ -42,7 +42,7 @@ def main(args):
     if args.action == 'list':
         regex = re.compile(args.regex) if args.regex else None
         for tree in sorted(database.trees.keys()):
-            if not regex or regex.match(tree):
+            if not regex or regex.fullmatch(tree):
                 print(tree)
     else:
         misc.raise_action_not_found(args.action, args.command)

--- a/kpet/cmd_tree.py
+++ b/kpet/cmd_tree.py
@@ -30,8 +30,12 @@ def build(cmds_parser, common_parser):
         help='List available kernel trees.',
         parents=[common_parser],
     )
+    list_parser.add_argument('-a', '--arch', metavar='REGEX',
+                             default=None,
+                             help='Limit output to trees with architectures '
+                             'matching the REGEX.')
     list_parser.add_argument('regex', nargs='?', default=None,
-                             help='Optional. Use this to filter results.')
+                             help='Limit output to trees matching the regex.')
 
 
 def main(args):
@@ -41,8 +45,14 @@ def main(args):
     database = data.Base(args.db)
     if args.action == 'list':
         regex = re.compile(args.regex or ".*")
-        for tree in sorted(database.trees.keys()):
-            if regex.fullmatch(tree):
-                print(tree)
+        arch_regex = re.compile(args.arch or ".*")
+        tree_names = set()
+        for name, value in database.trees.items():
+            filtered = list(filter(arch_regex.fullmatch, value['arches']))
+            if regex.fullmatch(name) and filtered:
+                tree_names.add(name)
+
+        for name in sorted(tree_names):
+            print(name)
     else:
         misc.raise_action_not_found(args.action, args.command)

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -225,7 +225,8 @@ class Base:     # pylint: disable=too-few-public-methods
                 default_for_string=True,
             ),
         )
-        template = jinja_env.get_template(self.database.trees[tree_name])
+        template = jinja_env.get_template(
+                        self.database.trees[tree_name]['template'])
         text = template.render(params)
 
         if lint:

--- a/tests/assets/db/general/index.yaml
+++ b/tests/assets/db/general/index.yaml
@@ -1,6 +1,8 @@
 trees:
-    rhel7: trees/rhel7.xml
-    rhel8: trees/rhel8.xml
+    rhel7:
+        template: trees/rhel7.xml
+    rhel8:
+        template: trees/rhel8.xml
 host_type_regex: ^normal
 host_types:
     normal: {}

--- a/tests/assets/db/general/limited/index.yaml
+++ b/tests/assets/db/general/limited/index.yaml
@@ -1,0 +1,39 @@
+trees:
+    rhel7:
+        template: rhel7
+        arches: x86_64
+    rhel8:
+        template: rhel8
+        arches: .*
+    upstream:
+        template: upstream
+        arches:
+            - x86_64
+            - aarch64
+    foo:
+        template: foo
+        arches:
+            - x86_64
+            - .*
+    bar:
+        template: bar
+        arches:
+            - ppc64le
+    baz:
+        template: baz
+        arches:
+            - ppc64.*
+host_type_regex: ^normal
+host_types:
+    normal: {}
+recipesets:
+    rcs1:
+      - normal
+arches:
+    - x86_64
+    - aarch64
+    - ppc64
+    - ppc64le
+suites:
+    - ../suites/default/index.yaml
+    - ../suites/fs/index.yaml

--- a/tests/test_cmd_tree.py
+++ b/tests/test_cmd_tree.py
@@ -28,6 +28,7 @@ class CmdTreeTest(unittest.TestCase):
         dbdir = os.path.join(os.path.dirname(__file__), 'assets/db/general')
         mock_args = mock.Mock()
         mock_args.db = dbdir
+        mock_args.arch = None
         mock_args.regex = None
         self.assertRaises(misc.ActionNotFound, cmd_tree.main, mock_args)
         mock_args.action = 'list'
@@ -35,6 +36,38 @@ class CmdTreeTest(unittest.TestCase):
             cmd_tree.main(mock_args)
         expected = [
             mock.call('rhel7'),
+            mock.call('\n'),
+            mock.call('rhel8'),
+            mock.call('\n'),
+        ]
+        self.assertListEqual(
+            expected,
+            mock_stdout.write.call_args_list,
+        )
+        mock_args.db = '/notfounddir'
+        self.assertRaises(Exception, cmd_tree.main, mock_args)
+
+    def test_list_arch_filter(self):
+        """
+        Check the proper exception is raised when action is not found, and if
+        an exception is raised when the database directory is invalid.
+        """
+        dbdir = os.path.join(os.path.dirname(__file__),
+                             'assets/db/general/limited')
+        mock_args = mock.Mock()
+        mock_args.db = dbdir
+        mock_args.arch = 'ppc64.*'
+        mock_args.regex = None
+        self.assertRaises(misc.ActionNotFound, cmd_tree.main, mock_args)
+        mock_args.action = 'list'
+        with mock.patch('sys.stdout') as mock_stdout:
+            cmd_tree.main(mock_args)
+        expected = [
+            mock.call('bar'),
+            mock.call('\n'),
+            mock.call('baz'),
+            mock.call('\n'),
+            mock.call('foo'),
             mock.call('\n'),
             mock.call('rhel8'),
             mock.call('\n'),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -61,7 +61,8 @@ INDEX_BASE_YAML = """
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 suites:
                     - suite.yaml
 """

--- a/tests/test_integration_match_suites_cases.py
+++ b/tests/test_integration_match_suites_cases.py
@@ -181,7 +181,8 @@ class IntegrationMatchSuitesCasesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 suites:
                     - suite1.yaml
                     - suite2.yaml
@@ -246,7 +247,8 @@ class IntegrationMatchSuitesCasesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 suites:
                     - suite1.yaml
                     - suite2.yaml
@@ -317,7 +319,8 @@ class IntegrationMatchSuitesCasesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 suites:
                     - suite1.yaml
                     - suite2.yaml

--- a/tests/test_integration_match_trees_arches.py
+++ b/tests/test_integration_match_trees_arches.py
@@ -34,7 +34,8 @@ class IntegrationMatchTreesArchesTests(IntegrationTests):
                     - ""
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 suites:
                     - suite.yaml
             """,
@@ -74,7 +75,8 @@ class IntegrationMatchTreesArchesTests(IntegrationTests):
                     - arch
                     - not_arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 suites:
                     - suite.yaml
             """,
@@ -118,7 +120,8 @@ class IntegrationMatchTreesArchesTests(IntegrationTests):
                     - not_arch
                     - other_arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 suites:
                     - suite.yaml
             """,
@@ -167,8 +170,10 @@ class IntegrationMatchTreesArchesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    "": .xml
-                    tree: tree.xml
+                    "":
+                        template: .xml
+                    tree:
+                        template: tree.xml
                 suites:
                     - suite.yaml
             """,
@@ -207,9 +212,12 @@ class IntegrationMatchTreesArchesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    "": .xml
-                    tree: tree.xml
-                    not_tree: not_tree.xml
+                    "":
+                        template: .xml
+                    tree:
+                        template: tree.xml
+                    not_tree:
+                        template: not_tree.xml
                 suites:
                     - suite.yaml
             """,
@@ -252,10 +260,14 @@ class IntegrationMatchTreesArchesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    "": .xml
-                    tree: tree.xml
-                    not_tree: not_tree.xml
-                    other_tree: other_tree.xml
+                    "":
+                        template: .xml
+                    tree:
+                        template: tree.xml
+                    not_tree:
+                        template: not_tree.xml
+                    other_tree:
+                        template: other_tree.xml
                 suites:
                     - suite.yaml
             """,

--- a/tests/test_integration_misc.py
+++ b/tests/test_integration_misc.py
@@ -47,7 +47,7 @@ class IntegrationMiscTests(IntegrationTests):
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             status=1,
-            stderr_matching=r'.*Architecture "arch" not found.*')
+            stderr_matching=r'.*Tree "tree" not found.*')
 
     def test_minimal_run_generate(self):
         """Test run generation with empty database"""

--- a/tests/test_integration_misc.py
+++ b/tests/test_integration_misc.py
@@ -71,7 +71,8 @@ class IntegrationMiscTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
             """,
             "tree.xml": COMMONTREE_XML,
         }
@@ -102,7 +103,8 @@ class IntegrationMiscTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    missing_template: missing_template.xml
+                    missing_template:
+                        template: missing_template.xml
             """,
         }
 
@@ -119,7 +121,8 @@ class IntegrationMiscTests(IntegrationTests):
         assets = {
             "index.yaml": INDEX_BASE_YAML + """
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 suites:
                     - missing.yaml
             """,
@@ -220,7 +223,8 @@ class IntegrationMiscTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 suites:
                     - suite.yaml
             """,

--- a/tests/test_integration_multihost_no_types.py
+++ b/tests/test_integration_multihost_no_types.py
@@ -41,7 +41,8 @@ class IntegrationMultihostNoTypesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
             """,
             "tree.xml": COMMONTREE_XML,
         }

--- a/tests/test_integration_multihost_types.py
+++ b/tests/test_integration_multihost_types.py
@@ -34,7 +34,8 @@ INDEX_BASE = """
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 host_types:
                     normal: {}
 """
@@ -68,7 +69,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 host_types:
                     normal: {}
                 suites:
@@ -142,7 +144,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 host_types:
                     normal: {}
                     not_normal: {}
@@ -195,7 +198,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 host_types:
                     normal: {}
                     not_normal: {}
@@ -247,7 +251,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 host_types:
                     a: {}
                     b: {}
@@ -299,7 +304,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 host_types:
                     a: {}
                     b: {}
@@ -352,7 +358,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 host_types:
                     a: {}
                     b: {}
@@ -410,7 +417,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
                 arches:
                     - arch
                 trees:
-                    tree: tree.xml
+                    tree:
+                        template: tree.xml
                 host_types:
                     a: {}
                     b: {}
@@ -458,7 +466,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
             arches:
                 - arch
             trees:
-                tree: tree.xml
+                tree:
+                    template: tree.xml
             host_types:
                 normal: {}
             suites:
@@ -511,7 +520,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
             arches:
                 - arch
             trees:
-                tree: tree.xml
+                tree:
+                    template: tree.xml
             host_types:
                 normal: {}
             suites:
@@ -556,7 +566,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
             arches:
                 - arch
             trees:
-                tree: tree.xml
+                tree:
+                    template: tree.xml
             host_types:
                 normal: {}
             host_type_regex: not_normal


### PR DESCRIPTION
example database index:
```
trees:
  foo:
    template: trees/foo.xml.j2
    arches: .*
  bar:
    template: trees/bar.xml.j2
    arches: .*
  baz:
    template: trees/baz.j2
    arches:
      - x86_64
      - aarch64
      - ppc64.*
```
And error when a case is expection a different arch than the tree has available
```
kpet.schema.Invalid: One of case patterns
match an unavailable tree/arch combination
In suite: /acpi/acpitable test
In case: ACPI table test
The arch: s390x
The tree: baz
The avaliable arches: ['x86_64', 'aarch64', 'ppc64', 'ppc64le']
```
Posting this as a WIP since there is much to discuss and fix at the moment, for example the error above might be unwanted since the test matched all arches and many trees yet this says it's not correct because a single tree doesn't support all arches

I suppose that should instead work so that the exception is raised if the only matching arch is the unavailible one

Also line 410 question: Do we want the 'trees: arches:' regexes to all match a arch or have them combined match at least a single arch?