### PR TITLE
Simplify tox configuration and ease linting

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ kpet.egg-info
 build
 dist
 .idea
+.coverage.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,9 @@ language: python
 dist: xenial
 python:
     - "3.7"
-env:
-    - TOX_ENV=flake8,pylint
 install:
     # Install kpet using pip to ensure dependencies are downloaded correctly.
     - pip install .[dev]
-    - pip install coveralls tox
 script:
-    - tox -e $(echo py${TRAVIS_PYTHON_VERSION} | tr -d .) -e ${TOX_ENV}
+    - tox -e py,coverage
     - pip uninstall -y kpet

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,12 +6,12 @@ Setup
 If you want to get started with KPET development, you can install the
 dependencies by running:
 ```bash
-$ pip install --user -e .
+$ pip install --user .[dev]
 ```
 
-Tests
------
-To run the tests, execute the following command:
+Tests + linting
+---------------
+To run the tests (together with linting), execute the following command:
 ```bash
-$ python3 setup.py test
+$ tox
 ```

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,11 +25,16 @@ install_requires = requests
                    PyYAML
                    lxml
 tests_require = mock
+python_requires = '>=3'
+setup_requires = flake8
 
 [options.extras_require]
 dev = flake8
       pycodestyle
       pylint
+      coverage
+      coveralls
+      tox
 
 [options.entry_points]
 # Set up an executable 'kpet' that calls the main() function in

--- a/setup.py
+++ b/setup.py
@@ -13,18 +13,6 @@
 # along with this program; if not, write to the Free Software Foundation, Inc.,
 # 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 """Install kpet using setuptools."""
-import sys
 from setuptools import setup
-
-python_required_major = 3
-python_required_minor = 6
-
-if sys.version_info.major < python_required_major or \
-   sys.version_info.major == python_required_major and \
-   sys.version_info.minor < python_required_minor:
-    sys.stderr.write("Python v{}.{} is required, but running v{}.{}".
-                     format(python_required_major, python_required_minor,
-                            sys.version_info.major, sys.version_info.minor))
-    sys.exit(1)
 
 setup()

--- a/tox.ini
+++ b/tox.ini
@@ -1,35 +1,19 @@
 [tox]
-envlist =
-    flake8
-    pylint
+# By default, use "test" (not defined explicitly) so that (1) it uses
+# the default Python version, and (2) it does _not_ run coverage. That
+# way, developers can simply type "tox" to run linting + tests, and
+# it's trivial for CI to run "tox -e test,coverage" or whatever to get
+# coverage, too.
+envlist = test
 
 [testenv]
 passenv = TRAVIS TRAVIS_*
-deps =
+whitelist_externals =
+    flake8
+    pylint
     coverage
-    mock
-    coveralls
-commands =
-    # NOTE Keep command line in sync with tests/test_integration.py
-    coverage run -p --branch --source=kpet -m unittest discover tests
-    coverage combine
-    coverage report -m
-    coveralls
-
-[testenv:flake8]
-passenv = CI TRAVIS TRAVIS_*
-basepython =
-    python3.7
-whitelist_externals = flake8
 commands =
     flake8 --show-source .
-
-[testenv:pylint]
-passenv = CI TRAVIS TRAVIS_*
-basepython =
-    python3.7
-whitelist_externals = pylint
-commands =
     # Disable R0801 in pylint that checks for duplicate content in multiple
     # files. See https://github.com/PyCQA/pylint/issues/214 for details.
     # Disable "Instance of 'Class' has no 'member' member (no-member)",
@@ -39,3 +23,16 @@ commands =
     # Disable warnings on detecting fixme-class comments, as we want to leave
     # such notes for fixing in later commits.
     pylint -d R0801 -d no-member -d c-extension-no-member -d fixme --ignored-classes=responses kpet tests
+    # NOTE Keep command line in sync with tests/test_integration.py
+    coverage run -p --branch --source=kpet -m unittest discover tests
+
+[testenv:coverage]
+passenv = TRAVIS TRAVIS_*
+whitelist_externals =
+    coverage
+    coveralls
+commands =
+    # NOTE Keep command line in sync with tests/test_integration.py
+    coverage combine
+    coverage report -m
+    coveralls


### PR DESCRIPTION
Simplify tox configuration and make it easier for developers (who might not have Python 3.7 installed in their machines) to run the linting and the tests with a single command.

Ref. FASTMOVING-1151