### PR TITLE
change the order of suites

### DIFF
--- a/kpet/run.py
+++ b/kpet/run.py
@@ -160,6 +160,9 @@ class Base:     # pylint: disable=too-few-public-methods
                     pool_suites.remove(pool_suite)
             # Add host to list, if it has suites to run
             if suites:
+                suites = list(sorted(suites, key=lambda suite:
+                                     [case for case in suite.cases if
+                                      case.waived] != []))
                 hosts.append(Host(host_type_name, host_type, suites))
 
         return hosts


### PR DESCRIPTION
Waived tests should be run as last. However, because we organize tests
into Suites, we have to change the order of Suites as well.
This patch puts Suites without waived Cases as first.

Signed-off-by: Jakub Racek <jracek@redhat.com>