### PR TITLE
Add support for suite and case IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Each recipe set is a *list* of "host" objects containing these attributes:
 
 Each suite is an object with the following attributes:
 
+* `name`: Name of the test suite.
 * `description`: Description of the test suite.
 * `hostRequires`: Jinja2 template path with the host requirements for
   the test run. Copied from the kpet database value of the same name.

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -325,6 +325,7 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
                     cases=List(Class(Case))
                 ),
                 optional=dict(
+                    name=String(),
                     host_type_regex=Regex(),
                     hostRequires=String(),
                     partitions=String(),

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -320,12 +320,13 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
         super().__init__(
             Struct(
                 required=dict(
-                    description=String(),
                     location=String(),
                     cases=List(Class(Case))
                 ),
                 optional=dict(
                     name=String(),
+                    # TODO Remove once database transitions to names
+                    description=String(),
                     host_type_regex=Regex(),
                     hostRequires=String(),
                     partitions=String(),
@@ -340,7 +341,11 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
         )
         if self.pattern is None:
             self.pattern = Pattern({})
+        # TODO Remove once database transitions to names
         if self.name is None:
+            if self.description is None:
+                raise Invalid(
+                    'The suite has neither name nor description specified.')
             self.name = self.description
 
     def matches(self, target):

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -340,6 +340,8 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
         )
         if self.pattern is None:
             self.pattern = Pattern({})
+        if self.name is None:
+            self.name = self.description
 
     def matches(self, target):
         """

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -423,7 +423,7 @@ class Base(Object):     # pylint: disable=too-few-public-methods
                         break
                 else:
                     raise Invalid(error.format("host_type_regex", "host_types",
-                                               suite.description, case.name,
+                                               suite.name, case.name,
                                                host_type_regex.pattern,
                                                host_types))
 
@@ -437,18 +437,18 @@ class Base(Object):     # pylint: disable=too-few-public-methods
             if self.origins is None:
                 if suite.origin is not None:
                     raise Invalid(
-                        f'Suite "{suite.description}" has origin specified, '
+                        f'Suite "{suite.name}" has origin specified, '
                         f'but available origins are not defined in '
                         f'the database.'
                     )
             else:
                 if suite.origin is None:
                     raise Invalid(
-                        f'Suite "{suite.description}" has no origin specified'
+                        f'Suite "{suite.name}" has no origin specified'
                     )
                 if suite.origin not in self.origins:
                     raise Invalid(
-                        f'Suite "{suite.description}" has unknown origin '
+                        f'Suite "{suite.name}" has unknown origin '
                         f'specified: "{suite.origin}".\n'
                         f'Expecting one of the following: '
                         f'{", ".join(self.origins.keys())}.'
@@ -533,7 +533,7 @@ class Base(Object):     # pylint: disable=too-few-public-methods
                 if not case.sets <= suite.sets:
                     raise Invalid("Case sets are not a subset of suite sets "
                                   "in suite: {}\ncase: {}".
-                                  format(suite.description, case.name))
+                                  format(suite.name, case.name))
 
     def __init__(self, dir_path):
         """

--- a/kpet/misc.py
+++ b/kpet/misc.py
@@ -24,6 +24,23 @@ def is_url(string):
     return bool(urlparse(string).scheme)
 
 
+def get_repeated(iterable):
+    """
+    Get the set of repeated items from an iterable.
+
+    Args:
+        iterable:   The iterable to get repeated items from.
+
+    Returns:
+        The set of repeated items.
+    """
+    item_set = set()
+    repeated_item_set = set()
+    for item in iterable:
+        (repeated_item_set if item in item_set else item_set).add(item)
+    return repeated_item_set
+
+
 def raise_action_not_found(action, command):
     """Raise the ActionNotFound exception"""
     raise ActionNotFound(

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -35,6 +35,7 @@ class Suite:
         for case in cases:
             assert case in suite.cases
 
+        self.id = suite.id  # pylint: disable=invalid-name
         self.name = suite.name
         # TODO Remove once database transitions to names
         self.description = suite.description

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -35,6 +35,7 @@ class Suite:
         for case in cases:
             assert case in suite.cases
 
+        self.name = suite.name
         self.description = suite.description
         self.hostRequires = suite.hostRequires  # pylint: disable=invalid-name
         self.partitions = suite.partitions

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -36,6 +36,7 @@ class Suite:
             assert case in suite.cases
 
         self.name = suite.name
+        # TODO Remove once database transitions to names
         self.description = suite.description
         self.hostRequires = suite.hostRequires  # pylint: disable=invalid-name
         self.partitions = suite.partitions

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,7 +41,7 @@ COMMONTREE_XML = """
     {% for HOST in recipeset %}
       HOST
       {% for suite in HOST.suites %}
-        {{ suite.description }}
+        {{ suite.name }}
         {% for case in suite.cases %}
           {{ case.name }}
         {% endfor %}

--- a/tests/test_integration_ids.py
+++ b/tests/test_integration_ids.py
@@ -1,0 +1,153 @@
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""Integration miscellaneous tests"""
+from tests.test_integration import (IntegrationTests, kpet_run_generate,
+                                    create_asset_files)
+
+INDEX_YAML = """
+    host_type_regex: ^normal
+    host_types:
+        normal: {}
+    recipesets:
+        rcs1:
+          - normal
+    arches:
+        - arch
+    trees:
+        tree:
+            template: tree.txt.j2
+    suites:
+        - suite1.yaml
+        - suite2.yaml
+"""
+
+SUITE_1_WITH_ONE_CASE_YAML = """
+    id: suite1
+    name: Suite
+    location: somewhere
+    cases:
+        - id: case
+          name: Case
+          max_duration_seconds: 100
+"""
+
+SUITE_2_WITH_ONE_CASE_YAML = """
+    id: suite2
+    name: Suite
+    location: somewhere
+    cases:
+        - id: case
+          name: Case
+          max_duration_seconds: 100
+"""
+
+SUITE_1_WITH_TWO_DIFFERENT_CASES = """
+    id: suite1
+    name: Suite
+    location: somewhere
+    cases:
+        - id: case1
+          name: Case
+          max_duration_seconds: 100
+    cases:
+        - id: case2
+          name: Case
+          max_duration_seconds: 200
+"""
+
+SUITE_2_WITH_TWO_DIFFERENT_CASES = """
+    id: suite2
+    name: Suite
+    location: somewhere
+    cases:
+        - id: case1
+          name: Case
+          max_duration_seconds: 100
+    cases:
+        - id: case2
+          name: Case
+          max_duration_seconds: 200
+"""
+
+SUITE_1_WITH_TWO_SAME_CASES = """
+    id: suite1
+    name: Suite
+    location: somewhere
+    cases:
+        - id: case1
+          name: Case
+          max_duration_seconds: 100
+        - id: case1
+          name: Case
+          max_duration_seconds: 200
+"""
+
+
+class IntegrationIdsTests(IntegrationTests):
+    """Integration tests for suite and case ID handling"""
+
+    def test_suite_ids(self):
+        """Test suites with repeated and non-repeated IDs work correctly"""
+        different_ids_assets_path = create_asset_files(self.test_dir, {
+            "index.yaml": INDEX_YAML,
+            "suite1.yaml": SUITE_1_WITH_ONE_CASE_YAML,
+            "suite2.yaml": SUITE_2_WITH_ONE_CASE_YAML,
+            "tree.txt.j2": ""
+        })
+        self.assertKpetProduces(
+            kpet_run_generate, different_ids_assets_path, "--no-lint",
+            stdout_matching=r'^$')
+
+        same_ids_assets_path = create_asset_files(self.test_dir, {
+            "index.yaml": INDEX_YAML,
+            "suite1.yaml": SUITE_1_WITH_ONE_CASE_YAML,
+            "suite2.yaml": SUITE_1_WITH_ONE_CASE_YAML,
+            "tree.txt.j2": ""
+        })
+        self.assertKpetProduces(
+            kpet_run_generate, same_ids_assets_path, "--no-lint",
+            status=1, stderr_matching=r".*repeated suite IDs: \{'suite1'\}.*")
+
+    def test_case_ids(self):
+        """Test cases with repeated and non-repeated IDs work correctly"""
+        different_ids_assets_path = create_asset_files(self.test_dir, {
+            "index.yaml": INDEX_YAML,
+            "suite1.yaml": SUITE_1_WITH_TWO_DIFFERENT_CASES,
+            "suite2.yaml": SUITE_2_WITH_ONE_CASE_YAML,
+            "tree.txt.j2": ""
+        })
+        self.assertKpetProduces(
+            kpet_run_generate, different_ids_assets_path, "--no-lint",
+            stdout_matching=r'^$')
+
+        same_ids_assets_path = create_asset_files(self.test_dir, {
+            "index.yaml": INDEX_YAML,
+            "suite1.yaml": SUITE_1_WITH_TWO_SAME_CASES,
+            "suite2.yaml": SUITE_2_WITH_ONE_CASE_YAML,
+            "tree.txt.j2": ""
+        })
+        self.assertKpetProduces(
+            kpet_run_generate, same_ids_assets_path, "--no-lint",
+            status=1, stderr_matching=r".*repeated case IDs: \{'case1'\}.*")
+
+        two_suites_with_same_case_ids_assets_path = \
+            create_asset_files(self.test_dir, {
+                "index.yaml": INDEX_YAML,
+                "suite1.yaml": SUITE_1_WITH_TWO_DIFFERENT_CASES,
+                "suite2.yaml": SUITE_2_WITH_TWO_DIFFERENT_CASES,
+                "tree.txt.j2": ""
+            })
+        self.assertKpetProduces(
+            kpet_run_generate, two_suites_with_same_case_ids_assets_path,
+            "--no-lint", stdout_matching=r'^$')

--- a/tests/test_integration_misc.py
+++ b/tests/test_integration_misc.py
@@ -19,7 +19,7 @@ from tests.test_integration import (IntegrationTests, kpet_run_generate,
 
 
 class IntegrationMiscTests(IntegrationTests):
-    """Integration tests expecting empty results or errors"""
+    """Miscellaneous integration tests"""
 
     def test_empty_tree_list(self):
         """Test tree listing with empty database"""

--- a/tests/test_integration_misc.py
+++ b/tests/test_integration_misc.py
@@ -323,3 +323,34 @@ class IntegrationMiscTests(IntegrationTests):
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             stdout_matching=r'.*<task>\s*Some preparation task\s*</task>.*')
+
+    def test_suites_expose_their_name(self):
+        """Test suites' "name" field should be exposed to Beaker templates"""
+        assets = {
+            "index.yaml": INDEX_BASE_YAML,
+            "suite.yaml": """
+                name: first_suite_with_name
+                description: suite1
+                location: somewhere
+                cases:
+                    - name: case1
+                      max_duration_seconds: 600
+            """,
+            "tree.xml": """
+            <job>
+              {% for recipeset in RECIPESETS %}
+                {% for HOST in recipeset %}
+                  {% for suite in HOST.suites %}
+                    {{ suite.name }}
+                  {% endfor %}
+                {% endfor %}
+              {% endfor %}
+            </job>
+            """,
+        }
+
+        assets_path = create_asset_files(self.test_dir, assets)
+
+        self.assertKpetProduces(
+            kpet_run_generate, assets_path,
+            stdout_matching=r'.*<job>\s*first_suite_with_name\s*</job>.*')


### PR DESCRIPTION
We are going to add an id to test suites. For that to happen, however,
we first need to _allow_ it without requiring it, then change kpet-db
to add it, then change the property to be required.

This is the first step.

Ref. FASTMOVING-1278