### PR TITLE
run: Abort rendering on accessing undefined vars

### DIFF
--- a/kpet/run.py
+++ b/kpet/run.py
@@ -269,6 +269,7 @@ class Base:     # pylint: disable=too-few-public-methods
                 enabled_extensions=('xml'),
                 default_for_string=True,
             ),
+            undefined=jinja2.StrictUndefined,
         )
         template = jinja_env.get_template(
                         self.database.trees[tree_name]['template'])


### PR DESCRIPTION
Abort template rendering if an undefined variable/attribute is accessed.
This will help us catch forgotten variable use, or typos.