### PR TITLE
run: Support specifying template variables

### DIFF
--- a/kpet/__init__.py
+++ b/kpet/__init__.py
@@ -16,7 +16,8 @@ import argparse
 import os
 import sys
 import logging
-from kpet import cmd_run, cmd_tree, cmd_arch, cmd_component, cmd_set
+from kpet import cmd_run, cmd_tree, cmd_arch, cmd_component, cmd_set, \
+                 cmd_variable
 from kpet import misc
 
 
@@ -57,6 +58,7 @@ def main(args=None):
     cmd_arch.build(cmds_parser, common_parser)
     cmd_component.build(cmds_parser, common_parser)
     cmd_set.build(cmds_parser, common_parser)
+    cmd_variable.build(cmds_parser, common_parser)
 
     args = parser.parse_args(args)
 
@@ -70,6 +72,7 @@ def main(args=None):
         'arch': [cmd_arch.main, args],
         'component': [cmd_component.main, args],
         'set': [cmd_set.main, args],
+        'variable': [cmd_variable.main, args],
     }
     try:
         exec_command(args, commands)

--- a/kpet/cmd_variable.py
+++ b/kpet/cmd_variable.py
@@ -1,0 +1,55 @@
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""The "variable" command"""
+import re
+
+from kpet import misc, data, cmd_misc
+
+
+def build(cmds_parser, common_parser):
+    """Build the argument parser for the variable command"""
+    _, action_subparser = cmd_misc.build(
+        cmds_parser,
+        common_parser,
+        "variable",
+        help='Template variable, default action "list".',
+    )
+
+    list_parser = action_subparser.add_parser(
+        "list",
+        help='List available template variables.',
+        parents=[common_parser],
+    )
+    list_parser.add_argument('regex', nargs='?', default=None,
+                             help='Regular expression fully matching '
+                                  'names of variables to output.')
+
+
+def main(args):
+    """Main function for the `variable` command"""
+    if not data.Base.is_dir_valid(args.db):
+        raise Exception("\"{}\" is not a database directory".format(args.db))
+    database = data.Base(args.db)
+    if args.action == 'list':
+        regex = re.compile(args.regex or ".*")
+        max_name_length = max((len(k) for k in database.variables), default=0)
+        for name, info in sorted(database.variables.items(),
+                                 key=lambda i: i[0]):
+            if regex.match(name):
+                print(f"{name: <{max_name_length}} {info['description']}")
+                if 'default' in info:
+                    print(f"{'': <{max_name_length}} "
+                          f"Default: {info['default']}")
+    else:
+        misc.raise_action_not_found(args.action, args.command)

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -528,7 +528,11 @@ class Base(Object):     # pylint: disable=too-few-public-methods
                         sets=Dict(String()),
                         host_types=Dict(Class(HostType)),
                         host_type_regex=Regex(),
-                        recipesets=Dict(List(String()))
+                        recipesets=Dict(List(String())),
+                        variables=Dict(
+                            Struct(required=dict(description=String()),
+                                   optional=dict(default=String()))
+                        ),
                     )
                 )
             ),
@@ -546,6 +550,8 @@ class Base(Object):     # pylint: disable=too-few-public-methods
             self.sets = {}
         if self.suites is None:
             self.suites = []
+        if self.variables is None:
+            self.variables = dict()
         # Regex check
         self.validate_host_type_regex()
         # Replace the list of regexes with a list of available arches

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -228,7 +228,8 @@ class Base:     # pylint: disable=too-few-public-methods
                                                          sets)
 
     # pylint: disable=too-many-arguments
-    def generate(self, description, kernel_location, lint, group=None):
+    def generate(self, description, kernel_location, lint, variables,
+                 group=None):
         """
         Generate Beaker XML which would execute tests in the database.
         The target supplied at creation must have exactly one tree and exactly
@@ -238,12 +239,14 @@ class Base:     # pylint: disable=too-few-public-methods
             description:        The run description string.
             kernel_location:    Kernel location string (a tarball or RPM URL).
             lint:               Lint and reformat the XML output, if True.
+            variables:          A dictionary of extra template variables.
         Returns:
             The beaker XML string.
         """
         assert isinstance(description, str)
         assert isinstance(kernel_location, str)
         assert isinstance(lint, bool)
+        assert isinstance(variables, dict)
         assert self.target.trees is not None and len(self.target.trees) == 1
         assert self.target.arches is not None and len(self.target.arches) == 1
 
@@ -256,6 +259,7 @@ class Base:     # pylint: disable=too-few-public-methods
             ARCH=arch_name,
             TREE=tree_name,
             RECIPESETS=self.recipesets_of_hosts,
+            VARIABLES=variables,
             getenv=os.getenv,
             group=group
         )

--- a/tests/test_cmd_run.py
+++ b/tests/test_cmd_run.py
@@ -36,7 +36,7 @@ class CmdRunTest(unittest.TestCase):
         target = data.Target(arches={'x86_64'}, trees={'rhel7'}, sources=None)
         baserun = run.Base(database, target, None)
         content = baserun.generate(description='Foo', kernel_location='bar',
-                                   lint=True)
+                                   lint=True, variables=dict())
         with open(os.path.join(self.dbdir, 'rhel7_rendered.xml')) as fhandle:
             content_expected = fhandle.read()
         self.assertEqual(content_expected, content)

--- a/tests/test_integration_variables.py
+++ b/tests/test_integration_variables.py
@@ -1,0 +1,125 @@
+# Copyright (c) 2019 Red Hat, Inc. All rights reserved. This copyrighted
+# material is made available to anyone wishing to use, modify, copy, or
+# redistribute it subject to the terms and conditions of the GNU General Public
+# License v.2 or later.
+#
+# This program is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+# FOR A PARTICULAR PURPOSE. See the GNU General Public License for more
+# details.
+#
+# You should have received a copy of the GNU General Public License along with
+# this program; if not, write to the Free Software Foundation, Inc., 51
+# Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+"""Template variable integration tests"""
+from tests.test_integration import (IntegrationTests, kpet_run_generate,
+                                    create_asset_files)
+
+
+# DB index.yaml with a required template variable "x"
+DB_YAML_REQUIRED_VARIABLE_X = """
+    host_types:
+        normal: {}
+    host_type_regex: ^normal
+    recipesets:
+        rcs1:
+          - normal
+    arches:
+        - arch
+    trees:
+        tree:
+            template: tree.xml
+    suites:
+        - suite.yaml
+    variables:
+        x:
+            description: Variable x
+"""
+
+# DB index.yaml with an optional template variable "x"
+DB_YAML_OPTIONAL_VARIABLE_X = \
+    DB_YAML_REQUIRED_VARIABLE_X + """
+            default: DEFAULT
+"""
+
+# An empty suite's YAML file
+SUITE_YAML_EMPTY = """
+    description: Empty suite
+    maintainers:
+      - maint1
+    cases: []
+
+"""
+
+# Database outputting a required template variable "x"
+DB_REQUIRED_VARIABLE_X = {
+    "index.yaml": DB_YAML_REQUIRED_VARIABLE_X,
+    "suite.yaml": SUITE_YAML_EMPTY,
+    "tree.xml": "{{ VARIABLES.x }}"
+}
+
+# Database outputting an optional template variable "x"
+DB_OPTIONAL_VARIABLE_X = {
+    "index.yaml": DB_YAML_OPTIONAL_VARIABLE_X,
+    "suite.yaml": SUITE_YAML_EMPTY,
+    "tree.xml": "{{ VARIABLES.x }}"
+}
+
+
+class IntegrationVariablesTests(IntegrationTests):
+    """Integration tests for template variable interface"""
+
+    def test_short_opt(self):
+        """Check short option is accepted"""
+        assets_path = create_asset_files(self.test_dir,
+                                         DB_REQUIRED_VARIABLE_X)
+
+        self.assertKpetProduces(kpet_run_generate, assets_path,
+                                "-v", "x=VALUE", "--no-lint",
+                                stdout_matching=r'VALUE')
+
+    def test_long_opt(self):
+        """Check long option is accepted"""
+        assets_path = create_asset_files(self.test_dir,
+                                         DB_REQUIRED_VARIABLE_X)
+
+        self.assertKpetProduces(kpet_run_generate, assets_path,
+                                "--variable", "x=VALUE", "--no-lint",
+                                stdout_matching=r'VALUE')
+
+    def test_required_not_specified(self):
+        """Check not specifying a required variable aborts rendering"""
+        assets_path = create_asset_files(self.test_dir,
+                                         DB_REQUIRED_VARIABLE_X)
+
+        self.assertKpetProduces(
+            kpet_run_generate, assets_path, "--no-lint", status=1,
+            stderr_matching=r'.*Required variables not set: x\..*')
+
+    def test_unknown_specified(self):
+        """Check specifying an unknown variable aborts rendering"""
+        assets_path = create_asset_files(self.test_dir,
+                                         DB_REQUIRED_VARIABLE_X)
+
+        self.assertKpetProduces(
+            kpet_run_generate, assets_path,
+            "--no-lint", "-v", "y=VALUE", status=1,
+            stderr_matching=r'.*Unknown variables specified: y\..*')
+
+    def test_optional_not_specified(self):
+        """Check not specifying an optional variable outputs defaults"""
+        assets_path = create_asset_files(self.test_dir,
+                                         DB_OPTIONAL_VARIABLE_X)
+
+        self.assertKpetProduces(
+            kpet_run_generate, assets_path, "--no-lint",
+            stdout_matching=r'DEFAULT')
+
+    def test_optional_specified(self):
+        """Check specifying an optional variable overrides default"""
+        assets_path = create_asset_files(self.test_dir,
+                                         DB_OPTIONAL_VARIABLE_X)
+
+        self.assertKpetProduces(kpet_run_generate, assets_path,
+                                "-v", "x=VALUE", "--no-lint",
+                                stdout_matching=r'VALUE')


### PR DESCRIPTION
Add support for specifying extra variables for templates on "kpet run
generate" command line. Add a separate sub-command "kpet variable" to
allow listing available variables and their defaults, which are
specified in the database. Verify no unknown variables are specified,
and all required variables are specified. Use defaults where set.

This is to replace the use of TESTS_BEAKER_ZIP_URL environment variable
and getenv, as well as the -g/--group option to "kpet run generate".

Concerns FASTMOVING-1340.