### PR TITLE
Make the "wrong database" error more helpful

### DIFF
--- a/kpet/cmd_arch.py
+++ b/kpet/cmd_arch.py
@@ -42,7 +42,7 @@ def build(cmds_parser, common_parser):
 def main(args):
     """Main function for the `arch` command"""
     if not data.Base.is_dir_valid(args.db):
-        raise Exception("\"{}\" is not a database directory".format(args.db))
+        misc.raise_invalid_database(args.db)
     database = data.Base(args.db)
     if args.action == 'list':
         regex = re.compile(args.regex or ".*")

--- a/kpet/cmd_component.py
+++ b/kpet/cmd_component.py
@@ -38,7 +38,7 @@ def build(cmds_parser, common_parser):
 def main(args):
     """Main function for the `component` command"""
     if not data.Base.is_dir_valid(args.db):
-        raise Exception("\"{}\" is not a database directory".format(args.db))
+        misc.raise_invalid_database(args.db)
     database = data.Base(args.db)
     if args.action == 'list':
         regex = re.compile(args.regex or ".*")

--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -255,7 +255,7 @@ def main_print_test_cases(args, baserun):
 def main(args):
     """Main function for the `run` command"""
     if not data.Base.is_dir_valid(args.db):
-        raise Exception("\"{}\" is not a database directory".format(args.db))
+        misc.raise_invalid_database(args.db)
     database = data.Base(args.db)
 
     if args.action == 'generate':

--- a/kpet/cmd_set.py
+++ b/kpet/cmd_set.py
@@ -38,7 +38,7 @@ def build(cmds_parser, common_parser):
 def main(args):
     """Main function for the `set` command"""
     if not data.Base.is_dir_valid(args.db):
-        raise Exception("\"{}\" is not a database directory".format(args.db))
+        misc.raise_invalid_database(args.db)
     database = data.Base(args.db)
     if args.action == 'list':
         regex = re.compile(args.regex or ".*")

--- a/kpet/cmd_tree.py
+++ b/kpet/cmd_tree.py
@@ -42,7 +42,7 @@ def build(cmds_parser, common_parser):
 def main(args):
     """Main function for the `tree` command"""
     if not data.Base.is_dir_valid(args.db):
-        raise Exception("\"{}\" is not a database directory".format(args.db))
+        misc.raise_invalid_database(args.db)
     database = data.Base(args.db)
     if args.action == 'list':
         regex = re.compile(args.regex or ".*")

--- a/kpet/cmd_variable.py
+++ b/kpet/cmd_variable.py
@@ -39,7 +39,7 @@ def build(cmds_parser, common_parser):
 def main(args):
     """Main function for the `variable` command"""
     if not data.Base.is_dir_valid(args.db):
-        raise Exception("\"{}\" is not a database directory".format(args.db))
+        misc.raise_invalid_database(args.db)
     database = data.Base(args.db)
     if args.action == 'list':
         regex = re.compile(args.regex or ".*")

--- a/kpet/misc.py
+++ b/kpet/misc.py
@@ -32,3 +32,11 @@ def raise_action_not_found(action, command):
             command
         )
     )
+
+
+def raise_invalid_database(database):
+    """Raise an exception for a wrong database"""
+    raise Exception(
+        '"{}" is not a database directory. '
+        'Maybe you need the --db option?'.format(database)
+    )


### PR DESCRIPTION
Mention in the error message that the --db option exists, so that the
user, especially if they're newcomers, are nudged towards a
solution. To achieve that, do a little refactoring so that the error
message is in a single place 😅