### PR TITLE
Remove default actions from help text

### DIFF
--- a/kpet/cmd_arch.py
+++ b/kpet/cmd_arch.py
@@ -23,7 +23,7 @@ def build(cmds_parser, common_parser):
         cmds_parser,
         common_parser,
         "arch",
-        help='Architecture to test on, default action "list"',
+        help='Architecture to test on',
     )
     list_parser = action_subparser.add_parser(
         "list",

--- a/kpet/cmd_component.py
+++ b/kpet/cmd_component.py
@@ -23,7 +23,7 @@ def build(cmds_parser, common_parser):
         cmds_parser,
         common_parser,
         "component",
-        help='Build component, default action "list".',
+        help='Build component',
     )
     list_parser = action_subparser.add_parser(
         "list",

--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -76,7 +76,7 @@ def build(cmds_parser, common_parser):
         cmds_parser,
         common_parser,
         'run',
-        help='Test suite run, default action "generate"',
+        help='Test suite run',
     )
     generate_parser = action_subparser.add_parser(
         "generate",

--- a/kpet/cmd_set.py
+++ b/kpet/cmd_set.py
@@ -23,7 +23,7 @@ def build(cmds_parser, common_parser):
         cmds_parser,
         common_parser,
         "set",
-        help='Test set, default action "list".',
+        help='Test set',
     )
     list_parser = action_subparser.add_parser(
         "list",

--- a/kpet/cmd_tree.py
+++ b/kpet/cmd_tree.py
@@ -23,7 +23,7 @@ def build(cmds_parser, common_parser):
         cmds_parser,
         common_parser,
         "tree",
-        help='Kernel tree, default action "list".',
+        help='Kernel tree',
     )
     list_parser = action_subparser.add_parser(
         "list",

--- a/kpet/cmd_variable.py
+++ b/kpet/cmd_variable.py
@@ -23,7 +23,7 @@ def build(cmds_parser, common_parser):
         cmds_parser,
         common_parser,
         "variable",
-        help='Template variable, default action "list".',
+        help='Template variable',
     )
 
     list_parser = action_subparser.add_parser(


### PR DESCRIPTION
They were not implemented, and implementing them might be hairy
because there might be confusion over where the options belong to when
the subactions are not specified, eg. "kpet run -h" is that asking for
help for "run" or for "run generate"? It's just... ugly conceptually.

Ref. FASTMOVING-1339