### PR TITLE
Add optional tasks for host types

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,10 @@ Each recipe set is a *list* of "host" objects containing these attributes:
   configuration. Copied from the kpet database value of the same name. See
   https://beaker-project.org/docs/admin-guide/kickstarts.html for more
   information.
+* `tasks`: Jinja2 template path with custom tasks (<task> elements)
+  for the host type. Copied from the kpet database value of the same
+  name. See https://beaker-project.org/docs/user-guide/tasks.html for
+  more information.
 * `suites`: List of test suites.
 
 Each suite is an object with the following attributes:

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -370,6 +370,7 @@ class HostType(Object):     # pylint: disable=too-few-public-methods
                 hostname=String(),
                 partitions=String(),
                 kickstart=String(),
+                tasks=String(),
             )),
             data
         )

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -70,6 +70,7 @@ class Host:
         self.hostRequires = type.hostRequires
         self.partitions = type.partitions
         self.kickstart = type.kickstart
+        self.tasks = type.tasks
         self.suites = suites
 
         self.name = name

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -46,6 +46,9 @@ COMMONTREE_XML = """
           {{ case.name }}
         {% endfor %}
       {% endfor %}
+      {% if HOST.tasks %}
+        {% include HOST.tasks %}
+      {% endif %}
     {% endfor %}
   {% endfor %}
 </job>

--- a/tests/test_integration_multihost_types.py
+++ b/tests/test_integration_multihost_types.py
@@ -53,8 +53,7 @@ class IntegrationMultihostTypesTests(IntegrationTests):
 
         assets_path = create_asset_files(self.test_dir, assets)
 
-        self.assertKpetSrcMatchesNoneOfTwoSuites(
-            assets_path)
+        self.assertKpetSrcMatchesNoneOfTwoSuites(assets_path)
 
     def test_multihost_one_type_no_regex_two_suites(self):
         """Test multihost support with one type, no regex, and two suites"""


### PR DESCRIPTION
In some cases, certain host types need extra tasks in the generated
Beaker XML. This change adds an optional attribute "tasks" for host
types, which should be a Jinja2 template path specifying the extra
<task> elements to copy in the Beaker XML.

Ref. FASTMOVING-1398