### PR TITLE
Clean up validation error messages

### DIFF
--- a/kpet/schema.py
+++ b/kpet/schema.py
@@ -51,11 +51,6 @@ _ReError = _get_re_error_type()
 class Invalid(Exception):
     """Invalid data exception"""
 
-    def __str__(self):
-        return super().__str__() + \
-               (":\n" + str(self.__context__) if self.__context__ is not None
-                else "")
-
 
 class Node:
     """

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -152,7 +152,7 @@ def kpet_run_generate(db_name, *args):
     Returns:
         Exit status, standard output, standard error
     """
-    return kpet_with_db(db_name,
+    return kpet_with_db(db_name, "--debug",
                         "run", "generate", "-t", "tree",
                         "-k", "kernel.tar.gz", "-a", "arch", *args)
 

--- a/tests/test_integration_match_sets.py
+++ b/tests/test_integration_match_sets.py
@@ -196,7 +196,7 @@ class IntegrationMatchSetsTests(IntegrationTests):
             kpet_run_generate, assets_path, "-s", "foo", status=1,
             stderr_matching=r'.*kpet.schema.Invalid: Case sets are not a '
                             r'subset of suite sets in suite:\s*'
-                            r'suite1\s*case: case1\s*')
+                            r'suite1\s*case: case1\b.*')
 
     def test_match_nonexistent_set_case_error(self):
         """

--- a/tests/test_integration_misc.py
+++ b/tests/test_integration_misc.py
@@ -150,7 +150,7 @@ class IntegrationMiscTests(IntegrationTests):
         assets_path = create_asset_files(self.test_dir, assets)
 
         self.assertKpetProduces(kpet_with_db, assets_path,
-                                "tree", "list",
+                                "--debug", "tree", "list",
                                 status=1,
                                 stderr_matching=r'.*yaml.parser.ParserError.*')
 
@@ -170,7 +170,7 @@ class IntegrationMiscTests(IntegrationTests):
         assets_path = create_asset_files(self.test_dir, assets)
 
         self.assertKpetProduces(kpet_with_db, assets_path,
-                                "tree", "list",
+                                "--debug", "tree", "list",
                                 status=1,
                                 stderr_matching=r'.*yaml.parser.ParserError.*')
 


### PR DESCRIPTION
In validation code we often throw exceptions inside exception
handlers, which makes Python report the exception like a problem while
handling the original exception. That's not good, first because it
looks like a bug in our code, and second because the validation error
output on the console becomes pretty big and it's very confusing to
read. So, explicitly clear up all references to the exception
"context" (by using "from None" at the end of the raise statement) for
all exceptions thrown inside a exception handler.

Ref. FASTMOVING-1456