### PR TITLE
Add a "maintainers" field to test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,5 @@ Each case is an object with the following attributes:
   ie. the bit after the "#".
 * `environment`: Dictionary with environment variables that should be
   set when running this test case.
+* `maintainers`: List of strings with the names and emails of the test
+  case maintainers.

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -291,6 +291,7 @@ class Case(Object):     # pylint: disable=too-few-public-methods
                     waived=Boolean(),
                     role=String(),
                     environment=Dict(String()),
+                    maintainers=List(String()),
                 )
             ),
             data
@@ -301,6 +302,8 @@ class Case(Object):     # pylint: disable=too-few-public-methods
             self.environment = {}
         if self.role is None:
             self.role = 'STANDALONE'
+        if self.maintainers is None:
+            self.maintainers = []
 
     def matches(self, target):
         """

--- a/tests/test_integration_misc.py
+++ b/tests/test_integration_misc.py
@@ -354,3 +354,47 @@ class IntegrationMiscTests(IntegrationTests):
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             stdout_matching=r'.*<job>\s*first_suite_with_name\s*</job>.*')
+
+    def test_cases_expose_their_maintainers(self):
+        """Test cases' "Maintainers" field should be exposed to templates"""
+        maintainer_name = "Some Maintainer <someone@maintainers.org>"
+        escaped_maintainer_name = (
+            maintainer_name.replace("<", "&lt;").replace(">", "&gt;")
+        )
+        assets = {
+            "index.yaml": INDEX_BASE_YAML,
+            "suite.yaml": """
+                name: first_suite_with_name
+                description: suite1
+                location: somewhere
+                cases:
+                    - name: case1
+                      max_duration_seconds: 600
+                      maintainers:
+                          - {}
+            """.format(maintainer_name),
+            "tree.xml": """
+            <job>
+              {% for recipeset in RECIPESETS %}
+                {% for HOST in recipeset %}
+                  {% for suite in HOST.suites %}
+                    {{ suite.name }}
+                    {% for case in suite.cases %}
+                      Maintainers:
+                      {% for maintainer in case.maintainers %}
+                        # {{ maintainer | e }}
+                      {% endfor %}
+                    {% endfor %}
+                  {% endfor %}
+                {% endfor %}
+              {% endfor %}
+            </job>
+            """,
+        }
+
+        assets_path = create_asset_files(self.test_dir, assets)
+
+        self.assertKpetProduces(
+            kpet_run_generate, assets_path,
+            stdout_matching=r'.*<job>.*first_suite_with_name.*'
+                            r'# {}.*</job>.*'.format(escaped_maintainer_name))


### PR DESCRIPTION
Add test case-level maintainers, and expose that to the Beaker XML
templates.

Ref. FASTMOVING-1438