### PR TITLE
Add a kpet.run class for test cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,8 +91,6 @@ Each suite is an object with the following attributes:
   information.
 * `maintainers`: List of strings with the names and emails of the test
   maintainers.
-* `url_suffix`: URL suffix to use in the Beaker task fetch URL,
-  ie. the bit after the "#".
 * `origin`: The name of a test suite origin - the source for the suite's code.
   One of the keys from the `origins` dictionary in the database's top
   `index.yaml` file. Undefined, if the latter is not defined. Examples:
@@ -125,8 +123,6 @@ Each case is an object with the following attributes:
 * `waived`: True if the test's failure should be ignored regarding the
   test run success/failure, eg. because it's new or unstable.
 * `role`: The value for the Beaker task's role attribute.
-* `url_suffix`: URL suffix to use in the Beaker task fetch URL,
-  ie. the bit after the "#".
 * `environment`: Dictionary with environment variables that should be
   set when running this test case.
 * `maintainers`: List of strings with the names and emails of the test

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -35,17 +35,14 @@ class Suite:
         for case in cases:
             assert case in suite.cases
 
-        self.id = suite.id  # pylint: disable=invalid-name
-        self.name = suite.name
-        # TODO Remove once database transitions to names
-        self.description = suite.description
-        self.hostRequires = suite.hostRequires  # pylint: disable=invalid-name
-        self.partitions = suite.partitions
-        self.kickstart = suite.kickstart
+        # TODO Remove "description" once database transitions to names
+        exported_attributes = ["id", "name", "description",
+                               "hostRequires", "partitions",
+                               "kickstart", "maintainers", "origin",
+                               "location"]
+        for attr in exported_attributes:
+            setattr(self, attr, getattr(suite, attr))
         self.cases = cases
-        self.maintainers = suite.maintainers
-        self.origin = suite.origin
-        self.location = suite.location
 
 
 class Host:

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -18,6 +18,24 @@ from lxml import etree
 from kpet import data
 
 
+class Case:
+    # pylint: disable=too-few-public-methods,too-many-instance-attributes
+    """A test case run"""
+    def __init__(self, case):
+        """
+        Initialize a test case run.
+
+        Args:
+            case:          The test cases to run.
+        """
+        exported_attributes = ["name", "max_duration_seconds", "hostRequires",
+                               "partitions", "kickstart", "waived", "role",
+                               "environment", "maintainers"]
+
+        for attr in exported_attributes:
+            setattr(self, attr, getattr(case, attr))
+
+
 class Suite:
     # pylint: disable=too-few-public-methods,too-many-instance-attributes
     """A test suite run"""
@@ -28,12 +46,11 @@ class Suite:
 
         Args:
             suite:          The suite to run.
-            cases:          List of the suite's cases to run.
+            cases:          List of the suite's cases to run (kpet.run.Case
+                            objects).
         """
         assert isinstance(suite, data.Suite)
         assert isinstance(cases, list)
-        for case in cases:
-            assert case in suite.cases
 
         # TODO Remove "description" once database transitions to names
         exported_attributes = ["id", "name", "description",
@@ -157,7 +174,7 @@ class Base:     # pylint: disable=too-few-public-methods
                         pool_cases.remove(case)
                 # Add the suite run to the list, if it has cases to run
                 if cases:
-                    suites.append(Suite(suite, cases))
+                    suites.append(Suite(suite, [Case(c) for c in cases]))
                 # Remove suite from the pool, if it has no more cases
                 if not pool_cases:
                     pool_suites.remove(pool_suite)


### PR DESCRIPTION
Other "data" classes have a simplified version in kpet.run. This is
the version that is passed to the templates, and only contain
attributes that are safe to put in templates. The exception for that
was Case, so create a kpet.run.Case class to make sure we only expose
the things we want.

Ref. FASTMOVING-1443