### PR TITLE
Make sure there is a maintainer for every testcase

### DIFF
--- a/kpet/data.py
+++ b/kpet/data.py
@@ -356,7 +356,7 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
                     pattern=Class(Pattern),
                     sets=sets_schema,
                     origin=String(),
-                    maintainers=List(String(), min_len=1)
+                    maintainers=List(String())
                 )
             ),
             data
@@ -370,6 +370,8 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
                     'The suite has neither name nor description specified.')
             self.name = self.description
         self.validate_case_ids()
+        if self.maintainers is None:
+            self.maintainers = []
 
     def matches(self, target):
         """

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -334,6 +334,19 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
             raise Invalid(f"The suite has repeated case IDs: "
                           f"{repeated_id_set}")
 
+    def validate_maintainers(self):
+        """
+        Check that every test case has a maintainer.
+        Raises:
+            schema.Invalid when a test case doesn't have any maintainers
+        """
+        for case in self.cases or []:
+            if not case.maintainers and not self.maintainers:
+                raise Invalid("There has to be a maintainer for each "
+                              "test, either at suite level or at case "
+                              "level; in suite: {}\ncase: {}".
+                              format(self.name, case.name))
+
     def __init__(self, data):
         sets_schema = Reduction(Regex(), lambda x: [x], List(Regex()))
 
@@ -372,6 +385,7 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
         self.validate_case_ids()
         if self.maintainers is None:
             self.maintainers = []
+        self.validate_maintainers()
 
     def matches(self, target):
         """

--- a/tests/test_integration_ids.py
+++ b/tests/test_integration_ids.py
@@ -36,6 +36,7 @@ SUITE_1_WITH_ONE_CASE_YAML = """
     id: suite1
     name: Suite
     location: somewhere
+    maintainers: ["maint1"]
     cases:
         - id: case
           name: Case
@@ -46,6 +47,7 @@ SUITE_2_WITH_ONE_CASE_YAML = """
     id: suite2
     name: Suite
     location: somewhere
+    maintainers: ["maint1"]
     cases:
         - id: case
           name: Case
@@ -56,6 +58,7 @@ SUITE_1_WITH_TWO_DIFFERENT_CASES = """
     id: suite1
     name: Suite
     location: somewhere
+    maintainers: ["maint1"]
     cases:
         - id: case1
           name: Case
@@ -70,6 +73,7 @@ SUITE_2_WITH_TWO_DIFFERENT_CASES = """
     id: suite2
     name: Suite
     location: somewhere
+    maintainers: ["maint1"]
     cases:
         - id: case1
           name: Case
@@ -84,6 +88,7 @@ SUITE_1_WITH_TWO_SAME_CASES = """
     id: suite1
     name: Suite
     location: somewhere
+    maintainers: ["maint1"]
     cases:
         - id: case1
           name: Case

--- a/tests/test_integration_misc.py
+++ b/tests/test_integration_misc.py
@@ -335,6 +335,7 @@ class IntegrationMiscTests(IntegrationTests):
                 cases:
                     - name: case1
                       max_duration_seconds: 600
+                      maintainers: ["maint1"]
             """,
             "tree.xml": """
             <job>


### PR DESCRIPTION
Now that we can specify maintainers at the test case level, we want to
allow specifying _only_ at that level and not at the suite level. That
failed before, so fix that and make sure that every test case has a
maintainer, either from the case itself, or from its containing suite.