### PR TITLE
Expose flat tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,10 @@ Each recipe set is a *list* of "host" objects containing these attributes:
   for the host type. Copied from the kpet database value of the same
   name. See https://beaker-project.org/docs/user-guide/tasks.html for
   more information.
-* `suites`: List of test suites.
+* `tests`: List of test. Essentially similar to `suites` but uses different
+  structure.
+* `suites`: List of test suites. Essentially similar to `tests` but uses
+  different structure.
 
 Each suite is an object with the following attributes:
 
@@ -131,3 +134,42 @@ Each case is an object with the following attributes:
   set when running this test case.
 * `maintainers`: List of strings with the names and emails of the test
   case maintainers.
+
+Each test is an object with the following attributes:
+
+* `id`: ID of the test.
+* `name`: Name of the test.
+* `origin`: The name of a test origin - the source for the test's code.
+  One of the keys from the `origins` dictionary in the database's top
+  `index.yaml` file. Undefined, if the latter is not defined. Examples:
+  `github`, `beaker`, or `suites_zip`. See the `origins` dictionary in the
+  database's top `index.yaml` for the available origins and the meanings they
+  assign to `location` values.
+* `location`: The location of the test's code, with whatever meaning the
+  database choses to assign to it, but must be interpreted according to the
+  `origin`, if specified. Examples: a tarball URL, a path inside a common
+  tarball, a Beaker task name. See the `origins` dictionary in the database's
+  top `index.yaml` for the available origins and the meanings they assign to
+  `location` values.
+* `max_duration_seconds`: Maximum number of seconds the test is allowed to
+  run.
+* `hostRequires`: a list of paths to Jinja2 templates with the host
+  requirements for the test run. Copied from the kpet database value of the
+  same name for both suites and cases.
+* `partitions`: a list of paths to Jinja2 templates with custom partition
+  configuration. Copied from the kpet database value of the same name for both
+  suites and cases. See
+  https://beaker-project.org/docs/user-guide/customizing-partitions.html
+  for more information.
+* `kickstart`: a list of paths to Jinja2 templates with custom Anaconda
+  kickstart configuration. Copied from the kpet database value of the same
+  name for both suites and cases. See
+  https://beaker-project.org/docs/admin-guide/kickstarts.html for more
+  information.
+* `waived`: True if the test's result should be ignored when summarizing the
+  overall run result, eg. because it's new or unstable.
+* `role`: The value for the Beaker task's role attribute.
+* `environment`: Dictionary with environment variables that should be
+  set when running this test.
+* `maintainers`: List of strings with the names and emails of the test
+  maintainers.

--- a/kpet/cmd_run.py
+++ b/kpet/cmd_run.py
@@ -243,14 +243,13 @@ def main_print_test_cases(args, baserun):
         args:       Parsed command-line arguments.
         baserun:    Test execution data.
     """
-    case_name_list = []
+    test_name_list = []
     for recipeset in baserun.recipesets_of_hosts:
         for host in recipeset:
-            for suite in host.suites:
-                for case in suite.cases:
-                    case_name_list.append(case.name)
-    for case_name in sorted(case_name_list):
-        print(case_name)
+            for test in host.tests:
+                test_name_list.append(test.name)
+    for test_name in sorted(test_name_list):
+        print(test_name)
 
 
 def main(args):

--- a/tests/assets/db/general/suites/default/index.yaml
+++ b/tests/assets/db/general/suites/default/index.yaml
@@ -1,4 +1,4 @@
-description: 'layout of ltplite for KPET'
+name: 'layout of ltplite for KPET'
 maintainers:
   - maint1
 location: distribution/ltp/lite

--- a/tests/assets/db/general/suites/default/index.yaml
+++ b/tests/assets/db/general/suites/default/index.yaml
@@ -1,4 +1,4 @@
-name: 'layout of ltplite for KPET'
+name: ''
 maintainers:
   - maint1
 location: distribution/ltp/lite

--- a/tests/assets/db/general/suites/fs/index.yaml
+++ b/tests/assets/db/general/suites/fs/index.yaml
@@ -1,4 +1,4 @@
-description: 'layout of xfs tests for KPET'
+name: 'layout of xfs tests for KPET'
 location: /filesystems/xfs/xfstests
 maintainers:
   - maint1

--- a/tests/assets/db/general/suites/fs/index.yaml
+++ b/tests/assets/db/general/suites/fs/index.yaml
@@ -1,4 +1,4 @@
-name: 'layout of xfs tests for KPET'
+name: ''
 location: /filesystems/xfs/xfstests
 maintainers:
   - maint1

--- a/tests/assets/db/general/trees/rhel7.xml
+++ b/tests/assets/db/general/trees/rhel7.xml
@@ -1,21 +1,17 @@
 {% macro host_add_tasks(host) -%}
-  {% for suite in host.suites %}
-    {% for case in suite.cases %}
-      <task name="{{ case['name'] }}" role="{{ case['role'] }}">
-        <fetch url="{{ VARIABLES.suites_zip_url }}#{{ suite.location }}"/>
-        <params>
-          {% if case['waived'] is not none %}
-            <param name="_WAIVED" value="{{ case['waived'] }}"/>
-          {% endif %}
-          {% set maint = suite['maintainers']|join(", ")|e %}
-          <param name="_MAINTAINERS" value="{{ maint }}"/>
-
-          {% for name in case.environment %}
-          <param name="{{ name }}" value="{{ case.environment[name] }}"/>
-          {% endfor %}
-        </params>
-      </task>
-    {% endfor %}
+  {% for test in host.tests %}
+    <task name="{{ test.name }}" role="{{ test.role }}">
+      <fetch url="{{ VARIABLES.suites_zip_url }}#{{ test.location }}"/>
+      <params>
+        {% if test.waived %}
+          <param name="_WAIVED" value="{{ test.waived }}"/>
+        {% endif %}
+        <param name="_MAINTAINERS" value="{{ test.maintainers | join(", ") | e }}"/>
+        {% for name, value in test.environment.items() %}
+          <param name="{{ name }}" value="{{ value }}"/>
+        {% endfor %}
+      </params>
+    </task>
   {% endfor %}
 {% endmacro %}
 
@@ -23,14 +19,9 @@
   {% if host[template_field] %}
     {% include host[template_field] %}
   {% endif %}
-  {% for suite in host.suites %}
-    {% if suite[template_field] %}
-      {% include suite[template_field] %}
-    {% endif %}
-    {% for case in suite.cases %}
-      {% if case[template_field] %}
-        {% include case[template_field] %}
-      {% endif %}
+  {% for test in host.tests %}
+    {% for template in test[template_field] %}
+      {% include template %}
     {% endfor %}
   {% endfor %}
 {% endmacro %}

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -40,11 +40,8 @@ COMMONTREE_XML = """
   {% for recipeset in RECIPESETS %}
     {% for HOST in recipeset %}
       HOST
-      {% for suite in HOST.suites %}
-        {{ suite.name }}
-        {% for case in suite.cases %}
-          {{ case.name }}
-        {% endfor %}
+      {% for test in HOST.tests %}
+        {{ test.name }}
       {% endfor %}
       {% if HOST.tasks %}
         {% include HOST.tasks %}
@@ -235,25 +232,25 @@ class IntegrationTests(unittest.TestCase):
         # Both appear in baseline output
         self.assertKpetProduces(
             kpet_run_generate, db_name,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*'
-                            r'suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*'
+                            r'suite2 - case2\s*</job>.*')
         # One appears with its patches
         self.assertKpetProduces(
             kpet_run_generate, db_name,
             get_patch_path("misc/files_abc.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Another appears with its patches
         self.assertKpetProduces(
             kpet_run_generate, db_name,
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite2 - case2\s*</job>.*')
         # Both appear with their patches
         self.assertKpetProduces(
             kpet_run_generate, db_name,
             get_patch_path("misc/files_abc.diff"),
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*'
-                            r'suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*'
+                            r'suite2 - case2\s*</job>.*')
         # None appear with other patches
         self.assertKpetProduces(
             kpet_run_generate, db_name,
@@ -270,12 +267,12 @@ class IntegrationTests(unittest.TestCase):
         # Only one appears in baseline output
         self.assertKpetProduces(
             kpet_run_generate, db_name,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # One appears with its patches
         self.assertKpetProduces(
             kpet_run_generate, db_name,
             get_patch_path("misc/files_abc.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Another doesn't appear with its patches
         self.assertKpetProduces(
             kpet_run_generate, db_name,
@@ -286,7 +283,7 @@ class IntegrationTests(unittest.TestCase):
             kpet_run_generate, db_name,
             get_patch_path("misc/files_abc.diff"),
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # None appear with other patches
         self.assertKpetProduces(
             kpet_run_generate, db_name,

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -71,7 +71,7 @@ INDEX_BASE_YAML = """
 """
 
 SUITE_BASE = """
-description: suite{}
+name: suite{}
 location: somewhere
 maintainers:
   - maint1

--- a/tests/test_integration_match_sets.py
+++ b/tests/test_integration_match_sets.py
@@ -43,7 +43,7 @@ class IntegrationMatchSetsTests(IntegrationTests):
                     baz: "dolor"
                 """,
             "suite1.yaml": """
-                  description: suite1
+                  name: suite1
                   location: somewhere
                   maintainers:
                     - maint1
@@ -54,7 +54,7 @@ class IntegrationMatchSetsTests(IntegrationTests):
                       max_duration_seconds: 600
             """,
             "suite2.yaml": """
-                  description: suite2
+                  name: suite2
                   location: somewhere
                   maintainers:
                     - maint2
@@ -106,7 +106,7 @@ class IntegrationMatchSetsTests(IntegrationTests):
                     baz: "dolor"
                 """,
             "suite1.yaml": """
-                  description: suite1
+                  name: suite1
                   location: somewhere
                   maintainers:
                     - maint1
@@ -119,7 +119,7 @@ class IntegrationMatchSetsTests(IntegrationTests):
                       sets: foo
             """,
             "suite2.yaml": """
-                  description: suite2
+                  name: suite2
                   location: somewhere
                   maintainers:
                     - maint2
@@ -172,7 +172,7 @@ class IntegrationMatchSetsTests(IntegrationTests):
                     baz: "dolor"
                 """,
             "suite1.yaml": """
-                  description: suite1
+                  name: suite1
                   location: somewhere
                   maintainers:
                     - maint1
@@ -223,7 +223,7 @@ class IntegrationMatchSetsTests(IntegrationTests):
                     baz: "dolor"
                 """,
             "suite1.yaml": """
-                  description: suite1
+                  name: suite1
                   location: somewhere
                   maintainers:
                     - maint1
@@ -273,7 +273,7 @@ class IntegrationMatchSetsTests(IntegrationTests):
                     baz: "dolor"
                 """,
             "suite1.yaml": """
-                  description: suite1
+                  name: suite1
                   location: somewhere
                   maintainers:
                     - maint1
@@ -324,7 +324,7 @@ class IntegrationMatchSetsTests(IntegrationTests):
                     baz: "dolor"
                 """,
             "suite1.yaml": """
-                  description: suite1
+                  name: suite1
                   location: somewhere
                   maintainers:
                     - maint1

--- a/tests/test_integration_match_sets.py
+++ b/tests/test_integration_match_sets.py
@@ -72,11 +72,11 @@ class IntegrationMatchSetsTests(IntegrationTests):
         # Matches suite
         self.assertKpetProduces(
             kpet_run_generate, assets_path, "-s", "foo",
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Matches a different suite
         self.assertKpetProduces(
             kpet_run_generate, assets_path, "-s", "bar",
-            stdout_matching=r'.*<job>\s*HOST\s*suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite2 - case2\s*</job>.*')
         # Doesn't match any suite
         self.assertKpetProduces(
             kpet_run_generate, assets_path, "-s", "baz",
@@ -140,11 +140,11 @@ class IntegrationMatchSetsTests(IntegrationTests):
         # Matches suite
         self.assertKpetProduces(
             kpet_run_generate, assets_path, "-s", "foo",
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Matches a different suite
         self.assertKpetProduces(
             kpet_run_generate, assets_path, "-s", "bar",
-            stdout_matching=r'.*<job>\s*HOST\s*suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite2 - case2\s*</job>.*')
 
     def test_match_not_subset_error(self):
         """

--- a/tests/test_integration_match_suites_cases.py
+++ b/tests/test_integration_match_suites_cases.py
@@ -37,12 +37,12 @@ class IntegrationMatchSuitesCasesTests(IntegrationTests):
         # Matches baseline
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Matches patches
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_abc.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
 
     def test_match_sources_one_case_one_pattern(self):
         """Test source-matching a case with one pattern"""
@@ -63,12 +63,12 @@ class IntegrationMatchSuitesCasesTests(IntegrationTests):
         # Matches baseline
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Matches patches it should
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_abc.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Doesn't match patches it shouldn't
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
@@ -96,23 +96,23 @@ class IntegrationMatchSuitesCasesTests(IntegrationTests):
         # Matches baseline
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Matches first patch
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_abc.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Matches second patch
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Matches both patches only once
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_abc.diff"),
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Doesn't match patches it shouldn't
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
@@ -143,25 +143,25 @@ class IntegrationMatchSuitesCasesTests(IntegrationTests):
         # Both match baseline
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*'
-                            r'case1\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*'
+                            r'suite1 - case2\s*</job>.*')
         # First matches its patch
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_abc.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Second matches its patch
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case2\s*</job>.*')
         # Both match their patches
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_abc.diff"),
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*'
-                            r'case1\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*'
+                            r'suite1 - case2\s*</job>.*')
         # None match other patches
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
@@ -209,25 +209,25 @@ class IntegrationMatchSuitesCasesTests(IntegrationTests):
         # Both match baseline
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*'
-                            r'suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*'
+                            r'suite2 - case2\s*</job>.*')
         # First matches its patch
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_abc.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Second matches its patch
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite2 - case2\s*</job>.*')
         # Both match their patches
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_abc.diff"),
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*'
-                            r'suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*'
+                            r'suite2 - case2\s*</job>.*')
         # None match other patches
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
@@ -283,24 +283,24 @@ class IntegrationMatchSuitesCasesTests(IntegrationTests):
         # Only non-specific suite matches baseline
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite2 - case2\s*</job>.*')
         # First matches its patch
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_abc.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Second matches its patch
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite2 - case2\s*</job>.*')
         # All suites can match if provided appropriate patches
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_abc.diff"),
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*'
-                            r'suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*'
+                            r'suite2 - case2\s*</job>.*')
         # None match other patches
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
@@ -349,24 +349,24 @@ class IntegrationMatchSuitesCasesTests(IntegrationTests):
         # Only non-specific case matches baseline
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite2 - case2\s*</job>.*')
         # First matches its patch
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_abc.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Second matches its patch
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite2 - case2\s*</job>.*')
         # All cases can match if provided appropriate patches
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             get_patch_path("misc/files_abc.diff"),
             get_patch_path("misc/files_def.diff"),
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*'
-                            r'suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*'
+                            r'suite2 - case2\s*</job>.*')
         # None match other patches
         self.assertKpetProduces(
             kpet_run_generate, assets_path,

--- a/tests/test_integration_match_suites_cases.py
+++ b/tests/test_integration_match_suites_cases.py
@@ -254,7 +254,7 @@ class IntegrationMatchSuitesCasesTests(IntegrationTests):
                     - suite2.yaml
             """,
             "suite1.yaml": """
-                description: suite1
+                name: suite1
                 location: somewhere
                 maintainers:
                   - maint1

--- a/tests/test_integration_match_trees_arches.py
+++ b/tests/test_integration_match_trees_arches.py
@@ -94,7 +94,7 @@ class IntegrationMatchTreesArchesTests(IntegrationTests):
         # Matches default ("arch") architecture
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Doesn't match empty architecture
         self.assertKpetProduces(
             kpet_run_generate, assets_path, "-a", "",
@@ -142,12 +142,12 @@ class IntegrationMatchTreesArchesTests(IntegrationTests):
         # Matches default ("arch") architecture
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Matches non-default (but listed) architecture
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             "-a", "other_arch",
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Doesn't match empty architecture
         self.assertKpetProduces(
             kpet_run_generate, assets_path, "-a", "",
@@ -237,7 +237,7 @@ class IntegrationMatchTreesArchesTests(IntegrationTests):
         # Matches default ("tree") tree
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Doesn't match empty tree
         self.assertKpetProduces(
             kpet_run_generate, assets_path, "-t", "",
@@ -291,12 +291,12 @@ class IntegrationMatchTreesArchesTests(IntegrationTests):
         # Matches default ("tree") tree
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Matches non-default (but listed) tree
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
             "-t", "other_tree",
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
         # Doesn't match empty tree
         self.assertKpetProduces(
             kpet_run_generate, assets_path, "-t", "",

--- a/tests/test_integration_misc.py
+++ b/tests/test_integration_misc.py
@@ -198,7 +198,7 @@ class IntegrationMiscTests(IntegrationTests):
                     - suite.yaml
             """,
             "suite.yaml": """
-                description: "Suite data with missing nodes"
+                name: "Suite data with missing nodes"
                 location: somewhere
                 maintainers:
                   - maint1
@@ -231,7 +231,7 @@ class IntegrationMiscTests(IntegrationTests):
                     - suite.yaml
             """,
             "suite.yaml": """
-                description: Empty suite
+                name: Empty suite
                 location: somewhere
                 maintainers:
                   - maint1
@@ -251,7 +251,7 @@ class IntegrationMiscTests(IntegrationTests):
         assets = {
             "index.yaml": INDEX_BASE_YAML,
             "suite.yaml": """
-                description: suite1
+                name: suite1
                 location: somewhere
                 maintainers:
                   - maint1
@@ -273,7 +273,7 @@ class IntegrationMiscTests(IntegrationTests):
         assets = {
             "index.yaml": INDEX_BASE_YAML,
             "suite.yaml": """
-                description: suite1
+                name: suite1
                 location: somewhere
                 maintainers:
                   - maint1
@@ -330,7 +330,6 @@ class IntegrationMiscTests(IntegrationTests):
             "index.yaml": INDEX_BASE_YAML,
             "suite.yaml": """
                 name: first_suite_with_name
-                description: suite1
                 location: somewhere
                 cases:
                     - name: case1
@@ -366,7 +365,6 @@ class IntegrationMiscTests(IntegrationTests):
             "index.yaml": INDEX_BASE_YAML,
             "suite.yaml": """
                 name: first_suite_with_name
-                description: suite1
                 location: somewhere
                 cases:
                     - name: case1

--- a/tests/test_integration_misc.py
+++ b/tests/test_integration_misc.py
@@ -266,7 +266,7 @@ class IntegrationMiscTests(IntegrationTests):
 
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
 
     def test_empty_case_with_a_pattern_run_generate(self):
         """Test run generation with an empty test case with a pattern"""
@@ -288,7 +288,7 @@ class IntegrationMiscTests(IntegrationTests):
 
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*</job>.*')
 
     def test_preparation_tasks_are_added(self):
         """Test source-matching with a specific case"""
@@ -340,8 +340,8 @@ class IntegrationMiscTests(IntegrationTests):
             <job>
               {% for recipeset in RECIPESETS %}
                 {% for HOST in recipeset %}
-                  {% for suite in HOST.suites %}
-                    {{ suite.name }}
+                  {% for test in HOST.tests %}
+                    {{ test.name }}
                   {% endfor %}
                 {% endfor %}
               {% endfor %}
@@ -353,7 +353,8 @@ class IntegrationMiscTests(IntegrationTests):
 
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*first_suite_with_name\s*</job>.*')
+            stdout_matching=r'.*<job>\s*first_suite_with_name - '
+                            r'case1\s*</job>.*')
 
     def test_cases_expose_their_maintainers(self):
         """Test cases' "Maintainers" field should be exposed to templates"""
@@ -376,13 +377,11 @@ class IntegrationMiscTests(IntegrationTests):
             <job>
               {% for recipeset in RECIPESETS %}
                 {% for HOST in recipeset %}
-                  {% for suite in HOST.suites %}
-                    {{ suite.name }}
-                    {% for case in suite.cases %}
-                      Maintainers:
-                      {% for maintainer in case.maintainers %}
-                        # {{ maintainer | e }}
-                      {% endfor %}
+                  {% for test in HOST.tests %}
+                    {{ test.name }}
+                    Maintainers:
+                    {% for maintainer in test.maintainers %}
+                      # {{ maintainer | e }}
                     {% endfor %}
                   {% endfor %}
                 {% endfor %}

--- a/tests/test_integration_multihost_types.py
+++ b/tests/test_integration_multihost_types.py
@@ -153,7 +153,7 @@ class IntegrationMultihostTypesTests(IntegrationTests):
                     - suite2.yaml
             """,
             "suite1.yaml": """
-                description: suite1
+                name: suite1
                 location: somewhere
                 maintainers:
                   - maint1
@@ -167,7 +167,7 @@ class IntegrationMultihostTypesTests(IntegrationTests):
                             - a
             """,
             "suite2.yaml": """
-                description: suite2
+                name: suite2
                 location: somewhere
                 maintainers:
                   - maint1
@@ -476,7 +476,7 @@ class IntegrationMultihostTypesTests(IntegrationTests):
                 - suite2.yaml
             """,
             "suite1.yaml": """
-            description: suite1
+            name: suite1
             location: somewhere
             maintainers:
               - maint1
@@ -490,7 +490,7 @@ class IntegrationMultihostTypesTests(IntegrationTests):
                         - a
             """,
             "suite2.yaml": """
-            description: suite2
+            name: suite2
             location: somewhere
             maintainers:
               - maint1

--- a/tests/test_integration_multihost_types.py
+++ b/tests/test_integration_multihost_types.py
@@ -286,8 +286,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
 
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*'
-                            r'HOST\s*suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*'
+                            r'HOST\s*suite2 - case2\s*</job>.*')
 
     def test_multihost_two_types_both_cases_first(self):
         """
@@ -340,8 +340,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
         # TODO Distinguish host types somehow
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*'
-                            r'suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*'
+                            r'suite2 - case2\s*</job>.*')
 
     def test_multihost_two_types_both_cases_second(self):
         """
@@ -394,8 +394,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
         # TODO Distinguish host types somehow
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*'
-                            r'suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*'
+                            r'suite2 - case2\s*</job>.*')
 
     def test_multihost_two_types_both_cases_both(self):
         """
@@ -453,8 +453,8 @@ class IntegrationMultihostTypesTests(IntegrationTests):
         # TODO Distinguish host types somehow
         self.assertKpetProduces(
             kpet_run_generate, assets_path,
-            stdout_matching=r'.*<job>\s*HOST\s*suite1\s*case1\s*'
-                            r'suite2\s*case2\s*</job>.*')
+            stdout_matching=r'.*<job>\s*HOST\s*suite1 - case1\s*'
+                            r'suite2 - case2\s*</job>.*')
 
     def test_multihost_one_type_suite_wrong_regex(self):
         """Test multihost schema invalid error with wrong suite regexes"""

--- a/tests/test_integration_origins.py
+++ b/tests/test_integration_origins.py
@@ -43,7 +43,7 @@ DB_YAML_WITH_ORIGINS = \
 
 # A suite YAML without origin specified
 SUITE_YAML_WITHOUT_ORIGIN = """
-    description: Suite
+    name: Suite
     location: somewhere
     maintainers:
       - maint1

--- a/tests/test_integration_variables.py
+++ b/tests/test_integration_variables.py
@@ -44,7 +44,7 @@ DB_YAML_OPTIONAL_VARIABLE_X = \
 
 # An empty suite's YAML file
 SUITE_YAML_EMPTY = """
-    description: Empty suite
+    name: Empty suite
     location: somewhere
     maintainers:
       - maint1


### PR DESCRIPTION
Expose flattened suites and cases as "tests" in kpet.run, for
simplicity. Exporting suites/cases is to be removed after the database
transitions to using tests.