### PR TITLE
Support universal IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ Each recipe set is a *list* of "host" objects containing these attributes:
 Each test is an object with the following attributes:
 
 * `name`: Name of the test.
+* `universal_id`: Universally-recognized ID of the test.
+  E.g. a [KCIDB](https://github.com/kernelci/kcidb/) test ID.
 * `origin`: The name of a test origin - the source for the test's code.
   One of the keys from the `origins` dictionary in the database's top
   `index.yaml` file. Undefined, if the latter is not defined. Examples:

--- a/README.md
+++ b/README.md
@@ -86,66 +86,7 @@ Each recipe set is a *list* of "host" objects containing these attributes:
   for the host type. Copied from the kpet database value of the same
   name. See https://beaker-project.org/docs/user-guide/tasks.html for
   more information.
-* `tests`: List of test. Essentially similar to `suites` but uses different
-  structure.
-* `suites`: List of test suites. Essentially similar to `tests` but uses
-  different structure.
-
-Each suite is an object with the following attributes:
-
-* `name`: Name of the test suite.
-* `description`: Description of the test suite.
-* `hostRequires`: Jinja2 template path with the host requirements for
-  the test run. Copied from the kpet database value of the same name.
-* `partitions`: Jinja2 template path with custom partition
-  configuration. Copied from the kpet database value of the same name. See
-  https://beaker-project.org/docs/user-guide/customizing-partitions.html
-  for more information.
-* `kickstart`: Jinja2 template path with custom Anaconda kickstart
-  configuration. Copied from the kpet database value of the same name. See
-  https://beaker-project.org/docs/admin-guide/kickstarts.html for more
-  information.
-* `waived`: True if the suites's failure should be ignored regarding the
-  test run success/failure, eg. because it's new or unstable.
-* `maintainers`: List of strings with the names and emails of the test
-  maintainers.
-* `origin`: The name of a test suite origin - the source for the suite's code.
-  One of the keys from the `origins` dictionary in the database's top
-  `index.yaml` file. Undefined, if the latter is not defined. Examples:
-  `github`, `beaker`, or `suites_zip`. See the `origins` dictionary in the
-  database's top `index.yaml` for the available origins and the meanings they
-  assign to `location` values.
-* `location`: The location of the suite's code, with whatever meaning the
-  database choses to assign to it, but must be interpreted according to the
-  `origin`, if specified. Examples: a tarball URL, a path inside a common
-  tarball, a Beaker task name. See the `origins` dictionary in the database's
-  top `index.yaml` for the available origins and the meanings they assign to
-  `location` values.
-* `cases`: List of test cases.
-
-Each case is an object with the following attributes:
-
-* `id`: ID of the test case, unique within the suite.
-* `name`: Test case name.
-* `max_duration_seconds`: Maximum number of seconds the test will be
-  allowed to run.
-* `hostRequires`: Jinja2 template path with the host requirements for
-  the test run. Copied from the kpet database value of the same name.
-* `partitions`: Jinja2 template path with custom partition
-  configuration. Copied from the kpet database value of the same name. See
-  https://beaker-project.org/docs/user-guide/customizing-partitions.html
-  for more information.
-* `kickstart`: Jinja2 template path with custom Anaconda kickstart
-  configuration. Copied from the kpet database value of the same name. See
-  https://beaker-project.org/docs/admin-guide/kickstarts.html for more
-  information.
-* `waived`: True if the test's failure should be ignored regarding the
-  test run success/failure, eg. because it's new or unstable.
-* `role`: The value for the Beaker task's role attribute.
-* `environment`: Dictionary with environment variables that should be
-  set when running this test case.
-* `maintainers`: List of strings with the names and emails of the test
-  case maintainers.
+* `tests`: List of tests.
 
 Each test is an object with the following attributes:
 

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -26,12 +26,13 @@ from kpet.schema import Invalid, Struct, Choice, \
 
 class Object:   # pylint: disable=too-few-public-methods
     """An abstract data object"""
-    def __init__(self, schema, data):
+    def __init__(self, name, schema, data):
         """
         Initialize an abstract data object with a schema validating and
         resolving a supplied data.
 
         Args:
+            name:   Name of the data instance to use in error messages.
             schema: The schema of the data, must recognize to a Struct.
             data:   The object data to be validated against and resolved with
                     the schema.
@@ -40,7 +41,7 @@ class Object:   # pylint: disable=too-few-public-methods
         try:
             data = schema.resolve(data)
         except Invalid:
-            raise Invalid("Invalid {} data".format(type(self).__name__))
+            raise Invalid("Invalid {}".format(name))
 
         # Recognize the schema
         schema = schema.recognize()
@@ -48,7 +49,7 @@ class Object:   # pylint: disable=too-few-public-methods
         try:
             schema.validate(data)
         except Invalid as exc:
-            raise Exception("Resolved data is invalid:\n{}".format(exc))
+            raise Exception("Resolved {} is invalid:\n{}".format(name, exc))
 
         # Assign members
         for member_name in schema.required.keys():
@@ -274,6 +275,7 @@ class Case(Object):     # pylint: disable=too-few-public-methods
     def __init__(self, data):
         sets_schema = Reduction(Regex(), lambda x: [x], List(Regex()))
         super().__init__(
+            "case",
             Struct(
                 required=dict(
                     max_duration_seconds=Int(),
@@ -336,6 +338,7 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
         sets_schema = Reduction(Regex(), lambda x: [x], List(Regex()))
 
         super().__init__(
+            "suite",
             Struct(
                 required=dict(
                     location=String(),
@@ -383,6 +386,7 @@ class HostType(Object):     # pylint: disable=too-few-public-methods
         Initialize a host type.
         """
         super().__init__(
+            "host type",
             Struct(optional=dict(
                 ignore_panic=Boolean(),
                 hostRequires=String(),
@@ -577,6 +581,7 @@ class Base(Object):     # pylint: disable=too-few-public-methods
         arches_schema = Reduction(Regex(), lambda x: [x], List(Regex()))
 
         super().__init__(
+            "database",
             ScopedYAMLFile(
                 Struct(
                     required=dict(

--- a/kpet/data.py
+++ b/kpet/data.py
@@ -24,6 +24,10 @@ from kpet.schema import Invalid, Struct, Choice, \
 # pylint: disable=raising-format-tuple,access-member-before-definition
 
 
+# Schema for universal IDs
+UNIVERSAL_ID_SCHEMA = String(pattern="[.a-zA-Z0-9_-]*")
+
+
 class Object:   # pylint: disable=too-few-public-methods
     """An abstract data object"""
     def __init__(self, name, schema, data):
@@ -282,6 +286,7 @@ class Case(Object):     # pylint: disable=too-few-public-methods
                 ),
                 optional=dict(
                     name=String(),
+                    universal_id=UNIVERSAL_ID_SCHEMA,
                     host_type_regex=Regex(),
                     hostRequires=String(),
                     partitions=String(),
@@ -346,6 +351,7 @@ class Suite(Object):    # pylint: disable=too-few-public-methods
                 ),
                 optional=dict(
                     name=String(),
+                    universal_id=UNIVERSAL_ID_SCHEMA,
                     host_type_regex=Regex(),
                     hostRequires=String(),
                     partitions=String(),

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -18,49 +18,6 @@ from lxml import etree
 from kpet import data
 
 
-class Case:
-    # pylint: disable=too-few-public-methods,too-many-instance-attributes
-    """A test case run"""
-    def __init__(self, case):
-        """
-        Initialize a test case run.
-
-        Args:
-            case:          The test cases to run.
-        """
-        exported_attributes = ["name", "max_duration_seconds", "hostRequires",
-                               "partitions", "kickstart", "waived", "role",
-                               "environment", "maintainers"]
-
-        for attr in exported_attributes:
-            setattr(self, attr, getattr(case, attr))
-
-
-class Suite:
-    # pylint: disable=too-few-public-methods,too-many-instance-attributes
-    """A test suite run"""
-
-    def __init__(self, suite, cases):
-        """
-        Initialize a test suite run.
-
-        Args:
-            suite:          The suite to run.
-            cases:          List of the suite's cases to run (kpet.run.Case
-                            objects).
-        """
-        assert isinstance(suite, data.Suite)
-        assert isinstance(cases, list)
-
-        exported_attributes = ["name",
-                               "hostRequires", "partitions",
-                               "kickstart", "maintainers", "origin",
-                               "location", "waived"]
-        for attr in exported_attributes:
-            setattr(self, attr, getattr(suite, attr))
-        self.cases = cases
-
-
 class Test:
     # pylint: disable=too-few-public-methods, too-many-instance-attributes
     """A test run - an execution of a particular case of a test suite"""
@@ -133,8 +90,6 @@ class Host:
         self.tasks = type.tasks
 
         # Collect host parameters and create "suite" and "test" lists
-        # TODO: Remove suite list once database transitions to "tests"
-        self.suites = list()
         self.tests = list()
         hostRequires_list = [type.hostRequires]
         partitions_list = [type.partitions]
@@ -148,8 +103,6 @@ class Host:
                 partitions_list.append(case.partitions)
                 kickstart_list.append(case.kickstart)
                 self.tests.append(Test(suite, case))
-            # TODO: Remove suite list once database transitions to "tests"
-            self.suites.append(Suite(suite, [Case(c) for c in cases]))
 
         # Remove undefined template paths
         self.hostRequires_list = filter(lambda e: e is not None,
@@ -160,9 +113,6 @@ class Host:
                                      kickstart_list)
 
         # Put waived tests at the end
-        # TODO: Remove suite list once database transitions to "tests"
-        self.suites.sort(key=lambda suite: len([case for case in suite.cases
-                                                if case.waived]))
         self.tests.sort(key=lambda t: t.waived)
 
 
@@ -184,7 +134,7 @@ class Base:     # pylint: disable=too-few-public-methods
 
         Returns:
             A list of recipesets - host synchronization domains - lists which
-            contain hosts with suites and their cases to be executed on them.
+            contain hosts with tests to be executed on them.
         """
         assert isinstance(database, data.Base)
         assert isinstance(target, data.Target)
@@ -269,7 +219,7 @@ class Base:     # pylint: disable=too-few-public-methods
                         included into the run. None if all suites and cases
                         should be included, regardless if members or not.
         Returns:
-            A list of Host instances with suite runs assigned to them
+            A list of Host instances with test runs assigned to them
         """
         assert isinstance(database, data.Base)
         assert isinstance(target, data.Target)

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -38,6 +38,10 @@ class Test:
         # pylint: disable=invalid-name
         self.name = " - ".join(filter(lambda x: x is not None,
                                       (suite.name, case.name)))
+        self.universal_id = \
+            case.universal_id if case.universal_id is not None else \
+            suite.universal_id if suite.universal_id is not None else \
+            None
         self.origin = suite.origin
         self.location = suite.location
         self.max_duration_seconds = case.max_duration_seconds

--- a/tests/test_integration_misc.py
+++ b/tests/test_integration_misc.py
@@ -188,7 +188,7 @@ class IntegrationMiscTests(IntegrationTests):
         self.assertKpetProduces(kpet_with_db, assets_path,
                                 "tree", "list",
                                 status=1,
-                                stderr_matching=r'.*Invalid Base data.*')
+                                stderr_matching=r'.*Invalid database.*')
 
     def test_invalid_suite_data_tree_list(self):
         """Test tree listing with invalid data in a suite file"""
@@ -210,7 +210,7 @@ class IntegrationMiscTests(IntegrationTests):
         self.assertKpetProduces(kpet_with_db, assets_path,
                                 "tree", "list",
                                 status=1,
-                                stderr_matching=r'.*Invalid Suite data.*')
+                                stderr_matching=r'.*Invalid suite.*')
 
     def test_empty_suite_run_generate(self):
         """Test run generation with an empty suite"""


### PR DESCRIPTION
This adds support for specifying "universal IDs" at suite or case level to allow identifying tests in kcidb and correlating with tests from other origins there.

This also drops exposing separate suites and cases to templates, as well as improves validation error messages a little.