### PR TITLE
run: Drop support for host-type-only host params

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,16 +59,6 @@ Each recipe set is a *list* of "host" objects containing these attributes:
 * `hostname`: Hostname if this will run on a specific machine, None otherwise.
 * `ignore_panic`: If kernel panics should be ignored when running
   tests. Copied from the kpet database value of the same name.
-* `hostRequires`: Jinja2 template path with the host requirements for
-  the test run. Copied from the kpet database value of the same name.
-* `partitions`: Jinja2 template path with custom partition
-  configuration. Copied from the kpet database value of the same name. See
-  https://beaker-project.org/docs/user-guide/customizing-partitions.html
-  for more information.
-* `kickstart`: Jinja2 template path with custom Anaconda kickstart
-  configuration. Copied from the kpet database value of the same name. See
-  https://beaker-project.org/docs/admin-guide/kickstarts.html for more
-  information.
 * `hostRequires_list`: a list of paths to Jinja2 templates with the host
   requirements for the test run. Contains the `hostRequires` database values
   of the host's type, and all the suites and cases executed on the host.

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -87,10 +87,6 @@ class Host:
         self.hostname = type.hostname
         self.ignore_panic = type.ignore_panic
         # pylint: disable=invalid-name
-        # TODO: Remove once database transitions to *_list fields
-        self.hostRequires = type.hostRequires
-        self.partitions = type.partitions
-        self.kickstart = type.kickstart
         self.tasks = type.tasks
 
         # Collect host parameters and create "suite" and "test" lists


### PR DESCRIPTION
Drop support for host-type-originating-only host parameters
("hostRequires", "partitions", and "kickstart") in the exposed "host"
objects. That is replaced with the "hostRequires_list",
"partitions_list", and "kickstart_list", containing host parameters
originating from the host, and the suites, and cases which run on it.