### PR TITLE
Rename hostRequires_list to host_requires_list

### DIFF
--- a/kpet/run.py
+++ b/kpet/run.py
@@ -91,22 +91,24 @@ class Host:
 
         # Collect host parameters and create "suite" and "test" lists
         self.tests = []
-        hostRequires_list = [type.hostRequires]
+        host_requires_list = [type.hostRequires]
         partitions_list = [type.partitions]
         kickstart_list = [type.kickstart]
         for suite, cases in suites_and_cases:
-            hostRequires_list.append(suite.hostRequires)
+            host_requires_list.append(suite.hostRequires)
             partitions_list.append(suite.partitions)
             kickstart_list.append(suite.kickstart)
             for case in cases:
-                hostRequires_list.append(case.hostRequires)
+                host_requires_list.append(case.hostRequires)
                 partitions_list.append(case.partitions)
                 kickstart_list.append(case.kickstart)
                 self.tests.append(Test(suite, case))
 
         # Remove undefined template paths
-        self.hostRequires_list = filter(lambda e: e is not None,
-                                        hostRequires_list)
+        self.host_requires_list = filter(lambda e: e is not None,
+                                         host_requires_list)
+        # TODO: For compatibility. Remove when kpet-db is updated.
+        self.hostRequires_list = self.host_requires_list
         self.partitions_list = filter(lambda e: e is not None,
                                       partitions_list)
         self.kickstart_list = filter(lambda e: e is not None,

--- a/tests/assets/db/general/trees/rhel7.xml
+++ b/tests/assets/db/general/trees/rhel7.xml
@@ -32,7 +32,7 @@
               <labcontroller op="=" value="example2.com"/>
               <labcontroller op="=" value="example3.com"/>
             </or>
-            {{- host_include_template_list(host, role, 'hostRequires_list') -}}
+            {{- host_include_template_list(host, role, 'host_requires_list') -}}
           </hostRequires>
           <repos/>
           <partitions>


### PR DESCRIPTION
Although it does hold a list of "hostRequires", it's a bit ugly that
we end up with a variable that has both mixedCase and snake_case in
the same name. So, default to the normal Python convention and use
"host_requires_list" for the variable.

However, need to keep hostRequires_list temporarily for compatibility
reasons.

NOTE: This is just to use the test bot, the "real" pull request is https://github.com/CKI-project/kpet/pull/140

Ref. FASTMOVING-1612