### PR TITLE
Fix list command output filtering

### DIFF
--- a/kpet/cmd_component.py
+++ b/kpet/cmd_component.py
@@ -45,7 +45,7 @@ def main(args):
         max_name_length = max((len(k) for k in database.components), default=0)
         for name, description in sorted(database.components.items(),
                                         key=lambda i: i[0]):
-            if regex.match(name):
+            if regex.fullmatch(name):
                 print(f"{name: <{max_name_length}} {description}")
     else:
         misc.raise_action_not_found(args.action, args.command)

--- a/kpet/cmd_set.py
+++ b/kpet/cmd_set.py
@@ -45,7 +45,7 @@ def main(args):
         max_name_length = max((len(k) for k in database.sets), default=0)
         for name, description in sorted(database.sets.items(),
                                         key=lambda i: i[0]):
-            if regex.match(name):
+            if regex.fullmatch(name):
                 print(f"{name: <{max_name_length}} {description}")
     else:
         misc.raise_action_not_found(args.action, args.command)

--- a/kpet/cmd_variable.py
+++ b/kpet/cmd_variable.py
@@ -46,7 +46,7 @@ def main(args):
         max_name_length = max((len(k) for k in database.variables), default=0)
         for name, info in sorted(database.variables.items(),
                                  key=lambda i: i[0]):
-            if regex.match(name):
+            if regex.fullmatch(name):
                 print(f"{name: <{max_name_length}} {info['description']}")
                 if 'default' in info:
                     print(f"{'': <{max_name_length}} "


### PR DESCRIPTION
Use re.fullmatch() instead of re.match() in *all* list commands to match
the promised "fully matching" from the usage message, when filtering the
objects to output.