### PR TITLE
Support postboot tasks for host types

### DIFF
--- a/kpet/data.py
+++ b/kpet/data.py
@@ -19,7 +19,7 @@ from functools import reduce
 from kpet import misc
 from kpet.schema import Invalid, Struct, Choice, \
     List, Dict, String, Regex, ScopedYAMLFile, YAMLFile, Class, Boolean, \
-    Int, Null, RE, Reduction
+    Int, Null, RE, Reduction, Succession
 
 # pylint: disable=raising-format-tuple,access-member-before-definition
 
@@ -391,16 +391,33 @@ class HostType(Object):     # pylint: disable=too-few-public-methods
         """
         Initialize a host type.
         """
+        # TODO Drop the old schema once kpet-db is switched to the new one
+        def inherit(data):
+            if "tasks" in data:
+                data["preboot_tasks"] = data.pop("tasks")
+            return data
         super().__init__(
             "host type",
-            Struct(optional=dict(
-                ignore_panic=Boolean(),
-                hostRequires=String(),
-                hostname=String(),
-                partitions=String(),
-                kickstart=String(),
-                tasks=String(),
-            )),
+            Succession(
+                Struct(optional=dict(
+                    ignore_panic=Boolean(),
+                    hostRequires=String(),
+                    hostname=String(),
+                    partitions=String(),
+                    kickstart=String(),
+                    tasks=String(),
+                )),
+                inherit,
+                Struct(optional=dict(
+                    ignore_panic=Boolean(),
+                    hostRequires=String(),
+                    hostname=String(),
+                    partitions=String(),
+                    kickstart=String(),
+                    preboot_tasks=String(),
+                    postboot_tasks=String(),
+                )),
+            ),
             data
         )
 

--- a/kpet/run.py
+++ b/kpet/run.py
@@ -87,7 +87,10 @@ class Host:
         self.hostname = type.hostname
         self.ignore_panic = type.ignore_panic
         # pylint: disable=invalid-name
-        self.tasks = type.tasks
+        self.preboot_tasks = type.preboot_tasks
+        self.postboot_tasks = type.postboot_tasks
+        # TODO Remove once kpet-db switches to preboot_tasks
+        self.tasks = type.preboot_tasks
 
         # Collect host parameters and create "suite" and "test" lists
         self.tests = []


### PR DESCRIPTION
Support specifying "preboot_tasks" and "postboot_tasks" for host types,
instead of just "tasks", which would be inserted before the "Boot test"
task by kpet-db.

Keep support for "tasks", so kpet-db could be upgraded at will.